### PR TITLE
Progression Lock Not Reapplied on Client After Returning to Menu

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -159,7 +159,6 @@ void UPSWorldSubsystem::OnPlayerTypeChanged(FPlayerTag PlayerTag)
 			PSCurrentSpotComponentInternal = SpotComponent;
 		}
 	}
-	CheckAndSetCharacterUnlockStatus();
 }
 
 void UPSWorldSubsystem::OnCharacterReady(APlayerCharacter* PlayerCharacter, int32 CharacterID)
@@ -342,67 +341,14 @@ void UPSWorldSubsystem::OnGameStateChanged(ECurrentGameState CurrentGameState)
 	switch (CurrentGameState)
 	{
 	case ECurrentGameState::Menu:
-		SwitchToLastSpotCharacter();
 	// refresh 3D Stars actors
 		UpdateProgressionActorsForSpot();
 		break;
 	case ECurrentGameState::GameStarting:
 		// Show Progression Menu widget in Main Menu
-		CheckAndSetCharacterUnlockStatus();
 		break;
 	default:
 		return;
-	}
-}
-
-// Updates the chosen player mesh on the level and switch current save game row
-void UPSWorldSubsystem::ChangeCurrentPlayer(UPSSpotComponent* SpotComponent)
-{
-	APlayerCharacter* LocalPlayerCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
-	if (!ensureMsgf(LocalPlayerCharacter, TEXT("ASSERT: 'LocalPlayerState' is not valid")))
-	{
-		return;
-	}
-
-	PSCurrentSpotComponentInternal = SpotComponent;
-	// Update the chosen player mesh on the level and switch current save game row
-	const FCustomPlayerMeshData& CustomPlayerMeshData = PSCurrentSpotComponentInternal ? PSCurrentSpotComponentInternal->GetMeshChecked().GetCustomPlayerMeshData() : FCustomPlayerMeshData::Empty;
-	if (CustomPlayerMeshData.IsValid())
-	{
-		LocalPlayerCharacter->SetCustomPlayerMeshData(CustomPlayerMeshData);
-		SetCurrentRowByTag(SpotComponent->GetMeshChecked().GetPlayerTag());
-	}
-}
-
-// Checks if the current character is unlocked and the player is allowed to play
-// if not allowed, sets the previous character
-void UPSWorldSubsystem::CheckAndSetCharacterUnlockStatus()
-{
-	if (UMyBlueprintFunctionLibrary::GetMyGameState()->GetCurrentGameState() == ECurrentGameState::GameStarting)
-	{
-		const FPSRowData& CurrentRowData = GetCurrentRow();
-		if (CurrentRowData.IsLevelLocked)
-		{
-			PSLastSpotComponentInternal = PSCurrentSpotComponentInternal;
-			for (UPSSpotComponent* SpotComponent : PSSpotComponentArrayInternal)
-			{
-				if (SpotComponent->GetMeshChecked().GetPlayerTag() == GetPreviousRow().Character)
-				{
-					// Update the chosen player mesh on the level and switch current save game row
-					ChangeCurrentPlayer(SpotComponent);
-				}
-			}
-		}
-	}
-}
-
-// Switches back to the last spot character in case of player tried to play with locked character as client
-void UPSWorldSubsystem::SwitchToLastSpotCharacter()
-{
-	if (PSLastSpotComponentInternal && PSCurrentSpotComponentInternal && PSLastSpotComponentInternal != PSCurrentSpotComponentInternal)
-	{
-		ChangeCurrentPlayer(PSLastSpotComponentInternal);
-		PSLastSpotComponentInternal = nullptr; //reset value in order to not repeat execution
 	}
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -57,6 +57,12 @@ const FPSRowData& UPSWorldSubsystem::GetCurrentRow() const
 // Set current row of progression system by tag
 void UPSWorldSubsystem::SetCurrentRowByTag(FPlayerTag NewRowPlayerTag)
 {
+	// check if current row is similar
+	if (GetCurrentRow().Character == NewRowPlayerTag)
+	{
+		return;
+	}
+
 	UPSSaveGameData* SaveGameInstance = GetCurrentSaveGameData();
 	checkf(SaveGameInstance, TEXT("ERROR: 'SaveGameInstanceInternal' is null"));
 
@@ -337,12 +343,15 @@ void UPSWorldSubsystem::OnGameStateChanged(ECurrentGameState CurrentGameState)
 	{
 	case ECurrentGameState::Menu:
 		SwitchToLastSpotCharacter();
-		// refresh 3D Stars actors
+	// refresh 3D Stars actors
 		UpdateProgressionActorsForSpot();
+		break;
 	case ECurrentGameState::GameStarting:
 		// Show Progression Menu widget in Main Menu
 		CheckAndSetCharacterUnlockStatus();
-	default: return;
+		break;
+	default:
+		return;
 	}
 }
 

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -103,10 +103,6 @@ protected:
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Category = "C++", meta = (BlueprintProtected, DisplayName = "Save Game Instance"))
 	TObjectPtr<class UPSSaveGameData> SaveGameInstanceInternal = nullptr;
 
-	/** Store the previous save row (previous not by count but last used, could different incerment */
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System Last Spot Component"))
-	TObjectPtr<class UPSSpotComponent> PSLastSpotComponentInternal = nullptr;
-
 	/** Array of pool actors handlers which should be released */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Pool Actors Handlers"))
 	TArray<FPoolObjectHandle> PoolActorHandlersInternal;
@@ -177,17 +173,5 @@ protected:
 	/** Called when the current game state was changed. */
 	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
-
-	/** Updates the chosen player mesh on the level and switch current save game row */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void ChangeCurrentPlayer(UPSSpotComponent* SpotComponent);
-	
-	/** Checks if the current character is unlocked and the player is allowed to play, and if not allowed, sets the previous character. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void CheckAndSetCharacterUnlockStatus();
-
-	/** Switches back to the last spot character in case of player tried to play with locked character as client */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void SwitchToLastSpotCharacter();
 	
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -27,6 +27,10 @@ public:
 	/** Returns current row of progression system */
 	const FPSRowData& GetCurrentRow() const;
 
+	/** Set current row of progression system by tag*/
+	UFUNCTION(BlueprintCallable, Category = "C++")
+	void SetCurrentRowByTag(FPlayerTag NewRowPlayerTag);
+
 	/** Returns previous row of progression system */
 	const FPSRowData& GetPreviousRow() const;
 
@@ -87,17 +91,21 @@ protected:
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System HUD Component"))
 	TObjectPtr<class UPSHUDComponent> PSHUDComponentInternal = nullptr;
 
-	/** Progression System Spot Component reference*/
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System HUD Component"))
+	/** Progression System Array of Spot Components */
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System Spot Array"))
 	TArray<class UPSSpotComponent*> PSSpotComponentArrayInternal;
 
 	/** Progression System Spot Component reference*/
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System HUD Component"))
-	TObjectPtr<class UPSSpotComponent> PSSpotComponentInternal = nullptr;
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System Spot Component"))
+	TObjectPtr<class UPSSpotComponent> PSCurrentSpotComponentInternal = nullptr;
 
 	/** Store the current save game instance */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Category = "C++", meta = (BlueprintProtected, DisplayName = "Save Game Instance"))
 	TObjectPtr<class UPSSaveGameData> SaveGameInstanceInternal = nullptr;
+
+	/** Store the previous save row (previous not by count but last used, could different incerment */
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System Last Spot Component"))
+	TObjectPtr<class UPSSpotComponent> PSLastSpotComponentInternal = nullptr;
 
 	/** Array of pool actors handlers which should be released */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Pool Actors Handlers"))
@@ -170,8 +178,16 @@ protected:
 	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
 
+	/** Updates the chosen player mesh on the level and switch current save game row */
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void ChangeCurrentPlayer(UPSSpotComponent* SpotComponent);
+	
 	/** Checks if the current character is unlocked and the player is allowed to play, and if not allowed, sets the previous character. */
 	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void CheckAndSetCharacterUnlockStatus();
+
+	/** Switches back to the last spot character in case of player tried to play with locked character as client */
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void SwitchToLastSpotCharacter();
 	
 };


### PR DESCRIPTION
https://trello.com/c/rOSx8elM/771-highbugps-progression-lock-not-reapplied-on-client-after-returning-to-menu

Fixed Progression Lock Not Reapplied on Client After Returning to Menu. 