### PR TITLE
Added Async load for the save game file from disc to prevent freezes

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
@@ -28,7 +28,7 @@ UPSHUDComponent::UPSHUDComponent()
 }
 
 // Called when main save game file is loaded
-void UPSHUDComponent::OnInitialized()
+void UPSHUDComponent::OnInitialized_Implementation()
 {
 	ProgressionMenuWidgetInternal = Cast<UPSMenuWidget>(FWidgetUtilsLibrary::CreateWidgetChecked(UPSDataAsset::Get().GetProgressionMenuWidget(), true, -10));
 
@@ -51,7 +51,7 @@ void UPSHUDComponent::OnInitialized()
 }
 
 // Subscribes to the end game state change notification on the player state.
-void UPSHUDComponent::OnLocalPlayerStateReady(AMyPlayerState* PlayerState, int32 CharacterID)
+void UPSHUDComponent::OnLocalPlayerStateReady_Implementation(AMyPlayerState* PlayerState, int32 CharacterID)
 {
 	// Ensure that PlayerState is not null before subscribing to the event
 	if (!ensureMsgf(PlayerState, TEXT("ASSERT: [%i] %hs:\n'PlayerState' is null!"), __LINE__, __FUNCTION__))
@@ -99,7 +99,7 @@ void UPSHUDComponent::SavePoints(EEndGameState EndGameState)
 }
 
 // Listening game states changes events 
-void UPSHUDComponent::OnGameStateChanged(ECurrentGameState CurrentGameState)
+void UPSHUDComponent::OnGameStateChanged_Implementation(ECurrentGameState CurrentGameState)
 {
 	CurrentGameStateInternal = CurrentGameState;
 	if (!ensureMsgf(ProgressionMenuWidgetInternal, TEXT("ASSERT: [%i] %hs:\n'ProgressionMenuWidgetInternal' is null!"), __LINE__, __FUNCTION__))
@@ -120,7 +120,7 @@ void UPSHUDComponent::OnGameStateChanged(ECurrentGameState CurrentGameState)
 }
 
 // Listening end game states changes events (win, lose, draw) 
-void UPSHUDComponent::OnEndGameStateChanged(EEndGameState EndGameState)
+void UPSHUDComponent::OnEndGameStateChanged_Implementation(EEndGameState EndGameState)
 {
 	if (EndGameState != EEndGameState::None)
 	{
@@ -134,7 +134,7 @@ void UPSHUDComponent::OnEndGameStateChanged(EEndGameState EndGameState)
 }
 
 // Handle events when player type changes
-void UPSHUDComponent::OnPlayerTypeChanged(FPlayerTag PlayerTag)
+void UPSHUDComponent::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
 	UpdateProgressionWidgetForPlayer();
 }

--- a/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
@@ -24,7 +24,7 @@ UPSSpotComponent::UPSSpotComponent()
 }
 
 // Called when progression module ready
-void UPSSpotComponent::OnInitialized()
+void UPSSpotComponent::OnInitialized_Implementation()
 {
 	// Ensure the component's mesh is properly assigned and not null.
 	PlayerSpotOnLevelInternal = GetMeshChecked();
@@ -68,7 +68,7 @@ UMySkeletalMeshComponent& UPSSpotComponent::GetMeshChecked() const
 }
 
 // Is called when a player has been changed
-void UPSSpotComponent::OnPlayerTypeChanged(FPlayerTag PlayerTag)
+void UPSSpotComponent::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
 	UMySkeletalMeshComponent& Mesh = GetMeshChecked();
 	if (Mesh.GetPlayerTag() == PlayerTag)
@@ -82,7 +82,7 @@ void UPSSpotComponent::OnPlayerTypeChanged(FPlayerTag PlayerTag)
 }
 
 //  Is called when a player has been changed 
-void UPSSpotComponent::OnCharacterReady(APlayerCharacter* PlayerCharacter, int32 CharacterID)
+void UPSSpotComponent::OnCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
 {
 	if (PlayerCharacter->GetPlayerTag() == GetMeshChecked().GetPlayerTag())
 	{

--- a/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
@@ -23,11 +23,9 @@ UPSSpotComponent::UPSSpotComponent()
 	PrimaryComponentTick.bStartWithTickEnabled = false;
 }
 
-// Called when the game starts
-void UPSSpotComponent::BeginPlay()
+// Called when progression module ready
+void UPSSpotComponent::OnInitialized()
 {
-	Super::BeginPlay();
-
 	// Ensure the component's mesh is properly assigned and not null.
 	PlayerSpotOnLevelInternal = GetMeshChecked();
 
@@ -39,6 +37,13 @@ void UPSSpotComponent::BeginPlay()
 
 	// Save reference of this component to the world subsystem
 	UPSWorldSubsystem::Get().RegisterSpotComponent(this);
+}
+
+// Called when the game starts
+void UPSSpotComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	UPSWorldSubsystem::Get().OnInitialize.AddDynamic(this, &ThisClass::OnInitialized);
 }
 
 // Clears all transient data created by this component.

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -143,8 +143,6 @@ void UPSWorldSubsystem::OnInitialized()
 	// Listen to handle input for each game state
 	BIND_ON_GAME_STATE_CHANGED(this, ThisClass::OnGameStateChanged);
 
-	// LoadGameFromSave();
-
 	StarDynamicProgressMaterial = UMaterialInstanceDynamic::Create(UPSDataAsset::Get().GetDynamicProgressionMaterial(), this);
 	if (!ensureMsgf(StarDynamicProgressMaterial, TEXT("ASSERT: [%i] %hs:\n'StarDynamicProgressMaterial' is null!"), __LINE__, __FUNCTION__))
 	{

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -135,7 +135,7 @@ void UPSWorldSubsystem::SetCurrentSpotComponent(UPSSpotComponent* MyHUDComponent
 }
 
 // Called when progression module ready
-void UPSWorldSubsystem::OnInitialized()
+void UPSWorldSubsystem::OnInitialized_Implementation()
 {
 	// Subscribe events on player type changed and Character spawned
 	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnCharacterReady);
@@ -185,7 +185,7 @@ void UPSWorldSubsystem::Deinitialize()
 }
 
 // Is called when a player character is ready
-void UPSWorldSubsystem::OnCharacterReady(APlayerCharacter* PlayerCharacter, int32 CharacterID)
+void UPSWorldSubsystem::OnCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
 {
 	if (!ensureMsgf(PlayerCharacter, TEXT("ASSERT: [%i] %s:\n'PlayerCharacter' is not valid!"), __LINE__, *FString(__FUNCTION__)))
 	{
@@ -195,7 +195,7 @@ void UPSWorldSubsystem::OnCharacterReady(APlayerCharacter* PlayerCharacter, int3
 }
 
 // Is called when a player has been changed
-void UPSWorldSubsystem::OnPlayerTypeChanged(FPlayerTag PlayerTag)
+void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
 	SetCurrentRowByTag(PlayerTag);
 
@@ -210,7 +210,7 @@ void UPSWorldSubsystem::OnPlayerTypeChanged(FPlayerTag PlayerTag)
 }
 
 // Called when the current game state was changed
-void UPSWorldSubsystem::OnGameStateChanged(ECurrentGameState CurrentGameState)
+void UPSWorldSubsystem::OnGameStateChanged_Implementation(ECurrentGameState CurrentGameState)
 {
 	switch (CurrentGameState)
 	{
@@ -332,7 +332,7 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 }
 
 // Triggers when a spot is loaded
-void UPSWorldSubsystem::OnSpotComponentLoad(UPSSpotComponent* SpotComponent)
+void UPSWorldSubsystem::OnSpotComponentLoad_Implementation(UPSSpotComponent* SpotComponent)
 {
 	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %s:\n'SpotComponent' is not valid!"), __LINE__, *FString(__FUNCTION__)))
 	{

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -231,7 +231,10 @@ void UPSWorldSubsystem::LoadGameFromSave()
 {
 	// load from data table
 	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
-	checkf(ProgressionDataTable, TEXT("ERROR: 'ProgressionDataTableInternal' is null"));
+	if (!ensureMsgf(ProgressionDataTable, TEXT("ASSERT: [%i] %s:\n'ProgressionDataTable' is not valid!"), __LINE__, *FString(__FUNCTION__)))
+	{
+		return;
+	}
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
 
 	// Check if the save game file exists
@@ -344,7 +347,10 @@ void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FS
 {
 	// load from data table
 	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
-	checkf(ProgressionDataTable, TEXT("ERROR: 'ProgressionDataTableInternal' is null"));
+	if (!ensureMsgf(ProgressionDataTable, TEXT("ASSERT: [%i] %s:\n'ProgressionDataTable' is not valid!"), __LINE__, *FString(__FUNCTION__)))
+	{
+		return;
+	}
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
 
 	SaveGameDataInternal = Cast<UPSSaveGameData>(SaveGame);

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -251,7 +251,7 @@ void UPSWorldSubsystem::LoadGameFromSave()
 
 		if (SaveGameDataInternal)
 		{
-			for (TTuple<FName, FPSRowData> Row : ProgressionSettingsDataInternal)
+			for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)
 			{
 				SaveGameDataInternal->SetProgressionMap(Row.Key, FPSSaveToDiskData::EmptyData);
 			}
@@ -361,7 +361,7 @@ void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FS
 
 		if (SaveGameDataInternal)
 		{
-			for (TTuple<FName, FPSRowData> Row : ProgressionSettingsDataInternal)
+			for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)
 			{
 				SaveGameDataInternal->SetProgressionMap(Row.Key, FPSSaveToDiskData::EmptyData);
 			}

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -165,8 +165,6 @@ void UPSWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 
 		if (GameFeatureName == "ProgressionSystem")
 		{
-			OnInitialize.AddDynamic(this, &ThisClass::OnInitialized);
-			
 			// Load save game data of the Main Menu
 			FAsyncLoadGameFromSlotDelegate AsyncLoadGameFromSlotDelegate;
 			AsyncLoadGameFromSlotDelegate.BindUObject(this, &ThisClass::OnAsyncLoadGameFromSlotCompleted);
@@ -365,7 +363,7 @@ void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FS
 	}
 
 	SetFirstElementAsCurrent();
-
+	OnInitialized();
 	OnInitialize.Broadcast();
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -168,7 +168,7 @@ void UPSWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 			// Load save game data of the Main Menu
 			FAsyncLoadGameFromSlotDelegate AsyncLoadGameFromSlotDelegate;
 			AsyncLoadGameFromSlotDelegate.BindUObject(this, &ThisClass::OnAsyncLoadGameFromSlotCompleted);
-			UGameplayStatics::AsyncLoadGameFromSlot(SaveGameDataInternal->GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex(), AsyncLoadGameFromSlotDelegate);
+			UGameplayStatics::AsyncLoadGameFromSlot(UPSSaveGameData::GetSaveSlotName(), UPSSaveGameData::GetSaveSlotIndex(), AsyncLoadGameFromSlotDelegate);
 		}
 	}
 }
@@ -238,9 +238,9 @@ void UPSWorldSubsystem::LoadGameFromSave()
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
 
 	// Check if the save game file exists
-	if (UGameplayStatics::DoesSaveGameExist(SaveGameDataInternal->GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex()))
+	if (UGameplayStatics::DoesSaveGameExist(UPSSaveGameData::GetSaveSlotName(), UPSSaveGameData::GetSaveSlotIndex()))
 	{
-		SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayStatics::LoadGameFromSlot(SaveGameDataInternal->GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex()));
+		SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayStatics::LoadGameFromSlot(UPSSaveGameData::GetSaveSlotName(), UPSSaveGameData::GetSaveSlotIndex()));
 	}
 	else
 	{
@@ -380,14 +380,14 @@ void UPSWorldSubsystem::SaveDataAsync() const
 	{
 		return;
 	}
-	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, SaveGameDataInternal->GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex());
+	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex());
 }
 
 // Removes all saved data of the Progression system and creates a new empty data
 void UPSWorldSubsystem::ResetSaveGameData()
 {
-	const FString& SlotName = SaveGameDataInternal->GetSaveSlotName();
-	const int32 UserIndex = SaveGameDataInternal->GetSaveSlotIndex();
+	const FString& SlotName = UPSSaveGameData::GetSaveSlotName();
+	const int32 UserIndex = UPSSaveGameData::GetSaveSlotIndex();
 
 	UGameplayUtilsLibrary::ResetSaveGameData(SaveGameDataInternal, SlotName, UserIndex);
 

--- a/Source/ProgressionSystemRuntime/Private/LevelActors/PSStarActor.cpp
+++ b/Source/ProgressionSystemRuntime/Private/LevelActors/PSStarActor.cpp
@@ -58,7 +58,7 @@ void APSStarActor::Tick(float DeltaTime)
 }
 
 // When a local character load finished
-void APSStarActor::OnLocalCharacterReady(APlayerCharacter* Character, int32 CharacterID)
+void APSStarActor::OnLocalCharacterReady_Implementation(APlayerCharacter* Character, int32 CharacterID)
 {
 	AMyPlayerController* LocalPC = Character ? Character->GetController<AMyPlayerController>() : nullptr;
 	if (ensureMsgf(LocalPC, TEXT("ASSERT: [%i] %hs:\n'LocalPC' is null!"), __LINE__, __FUNCTION__))
@@ -68,7 +68,7 @@ void APSStarActor::OnLocalCharacterReady(APlayerCharacter* Character, int32 Char
 }
 
 // Called when the current game state was changed
-void APSStarActor::OnGameStateChanged(ECurrentGameState GameState)
+void APSStarActor::OnGameStateChanged_Implementation(ECurrentGameState GameState)
 {
 	if (GameState == ECurrentGameState::Menu)
 	{
@@ -82,7 +82,7 @@ void APSStarActor::OnGameStateChanged(ECurrentGameState GameState)
 }
 
 // Is called when any cinematic started
-void APSStarActor::OnAnyCinematicStarted(const UObject* LevelSequence, const UObject* FromInstigator)
+void APSStarActor::OnAnyCinematicStarted_Implementation(const UObject* LevelSequence, const UObject* FromInstigator)
 {
 	SetStartTimeHideStars();
 	TryPlayHideStarAnimation();

--- a/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
@@ -54,8 +54,13 @@ protected:
 	* Protected functions
 	********************************************************************************************* */
 protected:
+	/** Called when progression module ready
+	 * Once the save file is loaded it activates the functionality of this class */
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnInitialized(); 
+	
 	/** Subscribes to the end game state change notification on the player state. */
-	UFUNCTION()
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnLocalPlayerStateReady(AMyPlayerState* PlayerState, int32 CharacterID);
 
 	/** Called when the game starts. */

--- a/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
@@ -25,11 +25,11 @@ public:
 	/** Save the progression depends on EEndGameState. */
 	UFUNCTION(BlueprintCallable, Category="C++")
 	void SavePoints(EEndGameState EndGameState);
-	
+
 	/** Updates the progression menu widget when player changed */
 	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void UpdateProgressionWidgetForPlayer();
-	
+
 	/*********************************************************************************************
 	* Protected properties
 	********************************************************************************************* */
@@ -45,22 +45,22 @@ protected:
 	/** Current game state. */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Current Game state"))
 	ECurrentGameState CurrentGameStateInternal = ECurrentGameState::None;
-	
+
 	/** Enabled Main Menu widget. */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Transient, Category="C++", meta = (BlueprintProtected, DisplayName = "Enable Main Menu Widget"))
 	bool PSMenuWidgetEnabledInternal = false;
-	
+
 	/*********************************************************************************************
 	* Protected functions
 	********************************************************************************************* */
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
-	void OnInitialized(); 
-	
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnInitialized();
+
 	/** Subscribes to the end game state change notification on the player state. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnLocalPlayerStateReady(AMyPlayerState* PlayerState, int32 CharacterID);
 
 	/** Called when the game starts. */
@@ -70,15 +70,15 @@ protected:
 	virtual void OnUnregister() override;
 
 	/** Called when the current game state was changed. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
 
 	/** Called when the end game state was changed. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnEndGameStateChanged(EEndGameState EndGameState);
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
 	/** Show locked level ui overlay */

--- a/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
@@ -56,7 +56,7 @@ protected:
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnInitialized(); 
 	
 	/** Subscribes to the end game state change notification on the player state. */
@@ -70,15 +70,15 @@ protected:
 	virtual void OnUnregister() override;
 
 	/** Called when the current game state was changed. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
 
 	/** Called when the end game state was changed. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnEndGameStateChanged(EEndGameState EndGameState);
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
 	/** Show locked level ui overlay */

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -47,11 +47,11 @@ protected:
 	virtual void OnUnregister() override;
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
 	/** Locks the player spot when progression for level achieved */

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -35,6 +35,11 @@ public:
 	FPSSpotComponent OnSpotComponentReady;
 
 protected:
+	/** Called when progression module ready
+	 * Once the save file is loaded it activates the functionality of this class */
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnInitialized();
+	
 	// Called when the game starts
 	virtual void BeginPlay() override;
 

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -37,7 +37,7 @@ public:
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent,BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnInitialized();
 	
 	// Called when the game starts
@@ -47,11 +47,11 @@ protected:
 	virtual void OnUnregister() override;
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
 	/** Locks the player spot when progression for level achieved */

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -145,7 +145,7 @@ protected:
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnInitialized();
 	
 	/** Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors */
@@ -155,15 +155,15 @@ protected:
 	virtual void Deinitialize() override;
 
 	/** Is called when a player character is ready */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
 	/** Called when the current game state was changed. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
 
 	/** Load game from save file or create a new one (does initial load from data table) */

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -145,7 +145,7 @@ protected:
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnInitialized();
 	
 	/** Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors */
@@ -155,15 +155,15 @@ protected:
 	virtual void Deinitialize() override;
 
 	/** Is called when a player character is ready */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
 	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
 	/** Called when the current game state was changed. */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintNativeEvent, BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
 
 	/** Load game from save file or create a new one (does initial load from data table) */
@@ -190,7 +190,7 @@ protected:
 	void OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectData>& CreatedObjects);
 
 	/** Triggers when a spot is loaded */
-	UFUNCTION(Blueprintable, Category="C++", meta=(BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, Blueprintable, Category="C++", meta=(BlueprintProtected))
 	void OnSpotComponentLoad(class UPSSpotComponent* SpotComponent);
 
 	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -20,6 +20,7 @@ class PROGRESSIONSYSTEMRUNTIME_API UPSWorldSubsystem : public UWorldSubsystem
 
 public:
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCurrentRowDataChanged, const FPlayerTag, SavedProgressionRowData);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnInitialize);
 
 	/** Returns this Subsystem, is checked and will crash if it can't be obtained.*/
 	static UPSWorldSubsystem& Get();
@@ -35,6 +36,10 @@ public:
 	/* Delegate for informing row data changed */
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
 	FCurrentRowDataChanged OnCurrentRowDataChanged;
+
+	/* Delegate for informing save game file is loaded/created if empty */
+	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
+	FPSOnInitialize OnInitialize;
 
 	/** Returns the data asset that contains all the assets of Progression System game feature.
 	 * @see UPSWorldSubsystem::PSDataAssetInternal. */
@@ -138,6 +143,11 @@ protected:
 	* Protected functions
 	********************************************************************************************* */
 protected:
+	/** Called when progression module ready
+	 * Once the save file is loaded it activates the functionality of this class */
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnInitialized();
+	
 	/** Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors */
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 
@@ -182,4 +192,8 @@ protected:
 	/** Triggers when a spot is loaded */
 	UFUNCTION(Blueprintable, Category="C++", meta=(BlueprintProtected))
 	void OnSpotComponentLoad(class UPSSpotComponent* SpotComponent);
+
+	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
 };

--- a/Source/ProgressionSystemRuntime/Public/LevelActors/PSStarActor.h
+++ b/Source/ProgressionSystemRuntime/Public/LevelActors/PSStarActor.h
@@ -66,15 +66,15 @@ protected:
 	float StartTimeMenuStarsInternal = 0.0f;
 
 	/** When a local character load finished */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent,BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void OnLocalCharacterReady(class APlayerCharacter* Character, int32 CharacterID);
 
 	/** Called when the current game state was changed */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState GameState);
 
 	/** Is called when any cinematic started to play in the main menu */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void OnAnyCinematicStarted(const UObject* LevelSequence, const UObject* FromInstigator);
 
 	/** Hiding stars with animation in main menu when cinematic is start to play */


### PR DESCRIPTION
https://trello.com/c/TEekHhPL/797-ps-make-saves-async-refactor-loadgamefromsave-to-prevent-freezes

Refactored: 
1. Loading of save game file from disck to be async
2.  Migrated to event FPSOnInitialize to inform all systems that module is initialized 
