### PR TITLE
[Bug] Fixed PS Data Asset loads multiple times

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -65,11 +65,7 @@ void UPSWorldSubsystem::SetCurrentRowByTag(FPlayerTag NewRowPlayerTag)
 // Returns the data asset that contains all the assets of Progression System game feature
 const UPSDataAsset* UPSWorldSubsystem::GetPSDataAsset() const
 {
-	if (!ensureMsgf(!PSDataAssetInternal.IsNull(), TEXT("ASSERT: [%i] %s:\n'PSDataAssetInternal' is empty!"), __LINE__, *FString(__FUNCTION__)))
-	{
-		return nullptr;
-	}
-	return PSDataAssetInternal.LoadSynchronous();
+	return UMyPrimaryDataAsset::GetOrLoadOnce(PSDataAssetInternal);
 }
 
 //  Returns a current save to disk row name
@@ -393,7 +389,7 @@ void UPSWorldSubsystem::PerformCleanUp()
 	StarDynamicProgressMaterial = nullptr;
 
 	// Subsystem clean up  
-	PSDataAssetInternal.Reset();
+	UMyPrimaryDataAsset::ResetDataAsset(PSDataAssetInternal);
 	PSHUDComponentInternal = nullptr;
 	PSSpotComponentArrayInternal.Empty();
 	PSCurrentSpotComponentInternal = nullptr;

--- a/Source/ProgressionSystemRuntime/Public/Data/PSDataAsset.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSDataAsset.h
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Valerii Rotermel & Yevhenii Selivanov
 
 #pragma once
-#include "Engine/DataAsset.h"
+
+#include "Data/MyPrimaryDataAsset.h"
 #include "Data/SettingTag.h"
 #include "PSDataAsset.generated.h"
 
@@ -10,13 +11,13 @@ enum class EGameDifficulty : uint8;
 /**
  * Contains all progression assets used in the module 
  */
-UCLASS()
-class PROGRESSIONSYSTEMRUNTIME_API UPSDataAsset : public UDataAsset
+UCLASS(Blueprintable, BlueprintType)
+class PROGRESSIONSYSTEMRUNTIME_API UPSDataAsset : public UMyPrimaryDataAsset
 {
 	GENERATED_BODY()
 
 public:
-	/** Returns the settings data asset. */
+	/** Returns the progression data asset or crash if can not be obtained. */
 	static const UPSDataAsset& Get();
 
 	/** Returns the Progression Data Table


### PR DESCRIPTION
https://trello.com/c/ZcGsaoVr/809-criticalbug-loadsynchronous-always-triggers-fsoftobjectpathtryload-for-all-bomber-data-assets

Reparented PS Data Asset to prevent multiple loading