### PR TITLE
[Low][Bug][PS] Unlock progress cheat does not activate currently locked character

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -366,8 +366,7 @@ void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FS
 			}
 		}
 	}
-	
-	
+
 
 	SetFirstElementAsCurrent();
 	OnInitialized();
@@ -384,7 +383,7 @@ void UPSWorldSubsystem::PerformCleanUp()
 		PoolActorHandlersInternal.Empty();
 		UPoolManagerSubsystem::Get().EmptyPool(UPSDataAsset::Get().GetStarActorClass());
 	}
-	
+
 	ProgressionSettingsDataInternal.Empty();
 	StarDynamicProgressMaterial = nullptr;
 
@@ -427,6 +426,13 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	{
 		return;
 	}
+
+	if (!ensureMsgf(PSCurrentSpotComponentInternal, TEXT("ASSERT: [%i] %hs:\n'PSCurrentSpotComponentInternal' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+	SetCurrentRowByTag(PSCurrentSpotComponentInternal->GetMeshChecked().GetPlayerTag());
+	PSCurrentSpotComponentInternal->ChangeSpotVisibilityStatus();
 	PSHUDComponent->UpdateProgressionWidgetForPlayer();
 	UpdateProgressionActorsForSpot();
 }
@@ -445,6 +451,12 @@ void UPSWorldSubsystem::UnlockAllLevels()
 	{
 		return;
 	}
+
+	if (!ensureMsgf(PSCurrentSpotComponentInternal, TEXT("ASSERT: [%i] %hs:\n'PSCurrentSpotComponentInternal' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+	PSCurrentSpotComponentInternal->ChangeSpotVisibilityStatus();
 	PSHUDComponent->UpdateProgressionWidgetForPlayer();
 	UpdateProgressionActorsForSpot();
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -421,20 +421,8 @@ void UPSWorldSubsystem::ResetSaveGameData()
 
 	// Re-load a new save game object. Load game from save creates a save file if there is no such
 	LoadGameFromSave();
-	UPSHUDComponent* PSHUDComponent = GetProgressionSystemHUDComponent();
-	if (!ensureMsgf(PSHUDComponent, TEXT("ASSERT: [%i] %hs:\n'PSHUDComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	if (!ensureMsgf(PSCurrentSpotComponentInternal, TEXT("ASSERT: [%i] %hs:\n'PSCurrentSpotComponentInternal' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
 	SetCurrentRowByTag(PSCurrentSpotComponentInternal->GetMeshChecked().GetPlayerTag());
-	PSCurrentSpotComponentInternal->ChangeSpotVisibilityStatus();
-	PSHUDComponent->UpdateProgressionWidgetForPlayer();
-	UpdateProgressionActorsForSpot();
+	RefreshProgressionUIElements();
 }
 
 // Unlocks all levels of the Progression System
@@ -446,6 +434,13 @@ void UPSWorldSubsystem::UnlockAllLevels()
 	}
 	SaveGameDataInternal->UnlockAllLevels();
 	SaveDataAsync();
+
+	RefreshProgressionUIElements();
+}
+
+// Is called to update the stars actors and in widgets
+void UPSWorldSubsystem::RefreshProgressionUIElements()
+{
 	UPSHUDComponent* PSHUDComponent = GetProgressionSystemHUDComponent();
 	if (!ensureMsgf(PSHUDComponent, TEXT("ASSERT: [%i] %hs:\n'PSHUDComponent' is null!"), __LINE__, __FUNCTION__))
 	{
@@ -456,6 +451,7 @@ void UPSWorldSubsystem::UnlockAllLevels()
 	{
 		return;
 	}
+
 	PSCurrentSpotComponentInternal->ChangeSpotVisibilityStatus();
 	PSHUDComponent->UpdateProgressionWidgetForPlayer();
 	UpdateProgressionActorsForSpot();

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -35,7 +35,7 @@ public:
 	FPSSpotComponent OnSpotComponentReady;
 
 	/** Locks the player spot when progression for level achieved */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta=(BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category= "C++")
 	void ChangeSpotVisibilityStatus();
 
 protected:

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -34,6 +34,10 @@ public:
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
 	FPSSpotComponent OnSpotComponentReady;
 
+	/** Locks the player spot when progression for level achieved */
+	UFUNCTION(BlueprintCallable, Category= "C++", meta=(BlueprintProtected))
+	void ChangeSpotVisibilityStatus();
+
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
@@ -53,10 +57,6 @@ protected:
 	/** Is called when a player has been changed */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
-
-	/** Locks the player spot when progression for level achieved */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta=(BlueprintProtected))
-	void ChangeSpotVisibilityStatus();
 
 	/** A player skeletal mesh actor */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Player Spot On Level"))

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -102,6 +102,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "C++")
 	void UnlockAllLevels();
 
+	/** Is called to update the stars actors and in widgets */
+	UFUNCTION(BlueprintCallable, Category = "C++")
+	void RefreshProgressionUIElements();
+
 	/** Returns difficultyMultiplier */
 	UFUNCTION(BlueprintCallable, Category="C++")
 	float GetDifficultyMultiplier();


### PR DESCRIPTION
https://trello.com/c/LoUgjcLG/807-lowbugps-unlock-progress-cheat-does-not-activate-currently-locked-character
fixed issue with  character, stars and overlay not appearing after using unlockAll/Reset progression cheats