### PR TITLE
[High][Bug][PS][Build] Overlay widget automatically displays when launch the build

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
@@ -74,6 +74,7 @@ void UPSOverlayWidget::NativeTick(const FGeometry& MyGeometry, float InDeltaTime
 void UPSOverlayWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
+	SetVisibility(ESlateVisibility::Collapsed);
 }
 
 // Play the overlay elements fade-in/fade-out animation. Uses the internal FadeCurveFloatInternal initialized in NativeConstruct


### PR DESCRIPTION
https://trello.com/c/1I5RP085/859-highbugpsbuild-overlay-widget-automatically-displays-when-launch-the-build
[High][Bug][PS][Build] Overlay widget automatically displays when launch the build - fixed, by setting widget to be hidden by default 