### PR TITLE
[High][Bug][PS][Build] ResetProgression-cheat always crashes the game

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
@@ -31,7 +31,7 @@ void UPSSpotComponent::OnInitialized_Implementation()
 
 	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
 	// Subscribe events on player type changed and Character spawned
-	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnCharacterReady);
+	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnLocalCharacterReady);
 
 	ChangeSpotVisibilityStatus();
 
@@ -89,7 +89,7 @@ void UPSSpotComponent::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 }
 
 //  Is called when a player has been changed 
-void UPSSpotComponent::OnCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
+void UPSSpotComponent::OnLocalCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
 {
 	if (PlayerCharacter->GetPlayerTag() == GetMeshChecked().GetPlayerTag())
 	{

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -330,8 +330,9 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 }
 
 // Returns spot component by the player tag, returns null if spot is not found
-UPSSpotComponent* UPSWorldSubsystem::FindSpotComponentByPlayerTag(FPlayerTag PlayerTag) const
+UPSSpotComponent* UPSWorldSubsystem::GetCurrentSpot() const
 {
+	FPlayerTag PlayerTag = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag();
 	if (PSSpotComponentArrayInternal.IsEmpty() || !PlayerTag.IsValid())
 	{
 		return nullptr;
@@ -440,7 +441,7 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	// Re-load a new save game object. Load game from save creates a save file if there is no such
 	LoadGameFromSave();
 
-	UPSSpotComponent* SpotComponent = FindSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
+	UPSSpotComponent* SpotComponent = GetCurrentSpot();
 	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
@@ -470,7 +471,7 @@ void UPSWorldSubsystem::RefreshProgressionUIElements()
 		return;
 	}
 
-	UPSSpotComponent* SpotComponent = FindSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
+	UPSSpotComponent* SpotComponent = GetCurrentSpot();
 	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -332,7 +332,7 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 // Returns spot component by the player tag, returns null if spot is not found
 UPSSpotComponent* UPSWorldSubsystem::FindSpotComponentByPlayerTag(FPlayerTag PlayerTag) const
 {
-	if (PSSpotComponentArrayInternal.IsEmpty())
+	if (PSSpotComponentArrayInternal.IsEmpty() || !PlayerTag.IsValid())
 	{
 		return nullptr;
 	}

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -220,6 +220,10 @@ void UPSWorldSubsystem::SetFirstElementAsCurrent()
 	{
 		return;
 	}
+	if (!ensureMsgf(SaveGameDataInternal, TEXT("ASSERT: [%i] %s:\n'SaveGameDataInternal' is not valid!"), __LINE__, *FString(__FUNCTION__)))
+	{
+		return;
+	}
 
 	CurrentRowNameInternal = FirstSaveToDiskRow;
 	SaveGameDataInternal->UnlockLevelByName(CurrentRowNameInternal);

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -329,6 +329,24 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 	}
 }
 
+// Returns spot component by the player tag, returns null if spot is not found
+UPSSpotComponent* UPSWorldSubsystem::GetSpotComponentByPlayerTag(FPlayerTag PlayerTag)
+{
+	if (PSSpotComponentArrayInternal.IsEmpty())
+	{
+		return nullptr;
+	}
+	
+	for (UPSSpotComponent* SpotComponent : PSSpotComponentArrayInternal)
+	{
+		if (SpotComponent->GetMeshChecked().GetPlayerTag() == PlayerTag)
+		{
+			return SpotComponent;
+		}
+	}
+	return nullptr;
+}
+
 // Triggers when a spot is loaded
 void UPSWorldSubsystem::OnSpotComponentLoad_Implementation(UPSSpotComponent* SpotComponent)
 {
@@ -421,8 +439,13 @@ void UPSWorldSubsystem::ResetSaveGameData()
 
 	// Re-load a new save game object. Load game from save creates a save file if there is no such
 	LoadGameFromSave();
-	SetCurrentRowByTag(PSCurrentSpotComponentInternal->GetMeshChecked().GetPlayerTag());
-	RefreshProgressionUIElements();
+
+	UPSSpotComponent* SpotComponent = GetSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
+	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+	SetCurrentRowByTag(SpotComponent->GetMeshChecked().GetPlayerTag());
 }
 
 // Unlocks all levels of the Progression System

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -441,12 +441,12 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	// Re-load a new save game object. Load game from save creates a save file if there is no such
 	LoadGameFromSave();
 
-	UPSSpotComponent* SpotComponent = GetCurrentSpot();
-	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
+	const APlayerCharacter* LocalCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
+	if (!ensureMsgf(LocalCharacter, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
 	}
-	SetCurrentRowByTag(SpotComponent->GetMeshChecked().GetPlayerTag());
+	SetCurrentRowByTag(LocalCharacter->GetPlayerTag());
 }
 
 // Unlocks all levels of the Progression System

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -139,7 +139,7 @@ void UPSWorldSubsystem::OnInitialized_Implementation()
 	}
 
 	// Subscribe events on player type changed and Character spawned
-	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnCharacterReady);
+	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnLocalCharacterReady);
 
 	// Listen to handle input for each game state
 	BIND_ON_GAME_STATE_CHANGED(this, ThisClass::OnGameStateChanged);
@@ -167,7 +167,7 @@ void UPSWorldSubsystem::OnWorldSubSystemInitialize_Implementation()
 }
 
 // Is called when a player character is ready
-void UPSWorldSubsystem::OnCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
+void UPSWorldSubsystem::OnLocalCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
 {
 	if (!ensureMsgf(PlayerCharacter, TEXT("ASSERT: [%i] %s:\n'PlayerCharacter' is not valid!"), __LINE__, *FString(__FUNCTION__)))
 	{

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -402,8 +402,8 @@ void UPSWorldSubsystem::ResetSaveGameData()
 		return;
 	}
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
-
-	check(SaveGameDataInternal); // todo checkf
+	
+	checkf(SaveGameDataInternal, TEXT("ERROR: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__);
 
 	for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)
 	{

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -470,12 +470,13 @@ void UPSWorldSubsystem::RefreshProgressionUIElements()
 		return;
 	}
 
-	if (!ensureMsgf(PSCurrentSpotComponentInternal, TEXT("ASSERT: [%i] %hs:\n'PSCurrentSpotComponentInternal' is null!"), __LINE__, __FUNCTION__))
+	UPSSpotComponent* SpotComponent = GetSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
+	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
 	}
 
-	PSCurrentSpotComponentInternal->ChangeSpotVisibilityStatus();
+	SpotComponent->ChangeSpotVisibilityStatus();
 	PSHUDComponent->UpdateProgressionWidgetForPlayer();
 	UpdateProgressionActorsForSpot();
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -127,25 +127,22 @@ void UPSWorldSubsystem::SetCurrentSpotComponent(UPSSpotComponent* MyHUDComponent
 		return;
 	}
 	PSCurrentSpotComponentInternal = MyHUDComponent;
-	UpdateProgressionActorsForSpot();
 }
 
 // Called when progression module ready
 void UPSWorldSubsystem::OnInitialized_Implementation()
 {
-	// Subscribe events on player type changed and Character spawned
-	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnCharacterReady);
-
-	// Listen to handle input for each game state
-	BIND_ON_GAME_STATE_CHANGED(this, ThisClass::OnGameStateChanged);
-
 	StarDynamicProgressMaterial = UMaterialInstanceDynamic::Create(UPSDataAsset::Get().GetDynamicProgressionMaterial(), this);
 	if (!ensureMsgf(StarDynamicProgressMaterial, TEXT("ASSERT: [%i] %hs:\n'StarDynamicProgressMaterial' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
 	}
 
-	UpdateProgressionActorsForSpot();
+	// Subscribe events on player type changed and Character spawned
+	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnCharacterReady);
+
+	// Listen to handle input for each game state
+	BIND_ON_GAME_STATE_CHANGED(this, ThisClass::OnGameStateChanged);
 }
 
 // Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors 
@@ -163,7 +160,7 @@ void UPSWorldSubsystem::Deinitialize()
 // Is called to initialize the world subsystem. It's a BeginPlay logic for the PS module
 void UPSWorldSubsystem::OnWorldSubSystemInitialize_Implementation()
 {
-	// Load save game data of the Main Menu
+	// Load save game data of the Progression system
 	FAsyncLoadGameFromSlotDelegate AsyncLoadGameFromSlotDelegate;
 	AsyncLoadGameFromSlotDelegate.BindUObject(this, &ThisClass::OnAsyncLoadGameFromSlotCompleted);
 	UGameplayStatics::AsyncLoadGameFromSlot(UPSSaveGameData::GetSaveSlotName(), UPSSaveGameData::GetSaveSlotIndex(), AsyncLoadGameFromSlotDelegate);
@@ -182,6 +179,8 @@ void UPSWorldSubsystem::OnCharacterReady_Implementation(APlayerCharacter* Player
 // Is called when a player has been changed
 void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
+	// todo refactor: in SetCurrentRowByTag function on broadcast OnCurrentRowDataChanged create a function which will
+	// perform all logic after this function call
 	SetCurrentRowByTag(PlayerTag);
 
 	for (UPSSpotComponent* SpotComponent : PSSpotComponentArrayInternal)
@@ -189,7 +188,7 @@ void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 		if (SpotComponent->GetMeshChecked().GetPlayerTag() == PlayerTag)
 		{
 			PSCurrentSpotComponentInternal = SpotComponent;
-			UpdateProgressionActorsForSpot();
+			UpdateProgressionStarActors();
 		}
 	}
 }
@@ -201,7 +200,7 @@ void UPSWorldSubsystem::OnGameStateChanged_Implementation(ECurrentGameState Curr
 	{
 	case ECurrentGameState::Menu:
 		// refresh 3D Stars actors
-		UpdateProgressionActorsForSpot();
+		UpdateProgressionStarActors();
 		break;
 	case ECurrentGameState::GameStarting:
 		// Show Progression Menu widget in Main Menu
@@ -211,66 +210,24 @@ void UPSWorldSubsystem::OnGameStateChanged_Implementation(ECurrentGameState Curr
 	}
 }
 
-// Load game from save file or create a new one (does initial load from data table)
-void UPSWorldSubsystem::LoadGameFromSave()
-{
-	// load from data table
-	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
-	if (!ensureMsgf(ProgressionDataTable, TEXT("ASSERT: [%i] %s:\n'ProgressionDataTable' is not valid!"), __LINE__, *FString(__FUNCTION__)))
-	{
-		return;
-	}
-	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
-
-	// Check if the save game file exists
-	if (UGameplayStatics::DoesSaveGameExist(UPSSaveGameData::GetSaveSlotName(), UPSSaveGameData::GetSaveSlotIndex()))
-	{
-		SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayStatics::LoadGameFromSlot(UPSSaveGameData::GetSaveSlotName(), UPSSaveGameData::GetSaveSlotIndex()));
-	}
-	else
-	{
-		// Save file does not exist
-		// do initial load from data table
-
-		SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayStatics::CreateSaveGameObject(UPSSaveGameData::StaticClass()));
-
-		if (SaveGameDataInternal)
-		{
-			for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)
-			{
-				SaveGameDataInternal->SetProgressionMap(Row.Key, FPSSaveToDiskData::EmptyData);
-			}
-		}
-	}
-
-	if (!ensureMsgf(SaveGameDataInternal, TEXT("ASSERT: [%i] %hs:\n'SaveGameDataInternal' failed to create!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	SetFirstElementAsCurrent();
-}
-
 // Always set first levels as unlocked on begin play
 void UPSWorldSubsystem::SetFirstElementAsCurrent()
 {
 	FName FirstSaveToDiskRow = GetFirstSaveToDiskRowName();
-	if (!FirstSaveToDiskRow.IsNone())
+
+	// early return if first element is not valid
+	if (FirstSaveToDiskRow.IsNone())
 	{
-		CurrentRowNameInternal = FirstSaveToDiskRow;
-		SaveGameDataInternal->UnlockLevelByName(CurrentRowNameInternal);
+		return;
 	}
+
+	CurrentRowNameInternal = FirstSaveToDiskRow;
+	SaveGameDataInternal->UnlockLevelByName(CurrentRowNameInternal);
 	SaveDataAsync();
 }
 
-// Updates the stars actors for a spot
-void UPSWorldSubsystem::UpdateProgressionActorsForSpot()
-{
-	AddProgressionStarActors();
-}
-
 // Spawn/add the stars actors for a spot
-void UPSWorldSubsystem::AddProgressionStarActors()
+void UPSWorldSubsystem::UpdateProgressionStarActors()
 {
 	//Return to Pool Manager the list of handles which is not needed (if there are any) 
 
@@ -337,7 +294,7 @@ UPSSpotComponent* UPSWorldSubsystem::GetCurrentSpot() const
 	{
 		return nullptr;
 	}
-	
+
 	for (UPSSpotComponent* SpotComponent : PSSpotComponentArrayInternal)
 	{
 		if (SpotComponent && SpotComponent->GetMeshChecked().GetPlayerTag() == PlayerTag)
@@ -362,7 +319,6 @@ void UPSWorldSubsystem::OnSpotComponentLoad_Implementation(UPSSpotComponent* Spo
 // Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load.
 void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FString& SlotName, int32 UserIndex, USaveGame* SaveGame)
 {
-	this->ReloadConfig();
 	// load from data table
 	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
 	if (!ensureMsgf(ProgressionDataTable, TEXT("ASSERT: [%i] %s:\n'ProgressionDataTable' is not valid!"), __LINE__, *FString(__FUNCTION__)))
@@ -372,9 +328,10 @@ void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FS
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
 
 	SaveGameDataInternal = Cast<UPSSaveGameData>(SaveGame);
+
 	if (!SaveGameDataInternal)
 	{
-		//  there is no save game file, or it is corrupted, create a new onew
+		//  there is no save game file, or it is corrupted, create a new one
 		SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayStatics::CreateSaveGameObject(UPSSaveGameData::StaticClass()));
 
 		if (SaveGameDataInternal)
@@ -385,7 +342,6 @@ void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FS
 			}
 		}
 	}
-
 
 	SetFirstElementAsCurrent();
 	OnInitialized();
@@ -421,12 +377,13 @@ void UPSWorldSubsystem::PerformCleanUp()
 }
 
 // Saves the progression to the local files
-void UPSWorldSubsystem::SaveDataAsync() const
+void UPSWorldSubsystem::SaveDataAsync()
 {
 	if (!ensureMsgf(SaveGameDataInternal, TEXT("ASSERT: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
 	}
+	
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex());
 }
 
@@ -436,10 +393,26 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	const FString& SlotName = UPSSaveGameData::GetSaveSlotName();
 	const int32 UserIndex = UPSSaveGameData::GetSaveSlotIndex();
 
-	UGameplayUtilsLibrary::ResetSaveGameData(SaveGameDataInternal, SlotName, UserIndex);
+	SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayUtilsLibrary::ResetSaveGameData(SaveGameDataInternal, SlotName, UserIndex));
 
-	// Re-load a new save game object. Load game from save creates a save file if there is no such
-	LoadGameFromSave();
+	// load from data table
+	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
+	if (!ensureMsgf(ProgressionDataTable, TEXT("ASSERT: [%i] %s:\n'ProgressionDataTable' is not valid!"), __LINE__, *FString(__FUNCTION__)))
+	{
+		return;
+	}
+	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
+
+	check(SaveGameDataInternal); // todo checkf
+
+	for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)
+	{
+		SaveGameDataInternal->SetProgressionMap(Row.Key, FPSSaveToDiskData::EmptyData);
+	}
+
+	// Re-load save game object. Load game from save file or if there is no such creates a new one
+	SetFirstElementAsCurrent();
+	UpdateProgressionUI();
 
 	const APlayerCharacter* LocalCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
 	if (!ensureMsgf(LocalCharacter, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
@@ -458,28 +431,7 @@ void UPSWorldSubsystem::UnlockAllLevels()
 	}
 	SaveGameDataInternal->UnlockAllLevels();
 	SaveDataAsync();
-
-	RefreshProgressionUIElements();
-}
-
-// Is called to update the stars actors and in widgets
-void UPSWorldSubsystem::RefreshProgressionUIElements()
-{
-	UPSHUDComponent* PSHUDComponent = GetProgressionSystemHUDComponent();
-	if (!ensureMsgf(PSHUDComponent, TEXT("ASSERT: [%i] %hs:\n'PSHUDComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	UPSSpotComponent* SpotComponent = GetCurrentSpot();
-	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	SpotComponent->ChangeSpotVisibilityStatus();
-	PSHUDComponent->UpdateProgressionWidgetForPlayer();
-	UpdateProgressionActorsForSpot();
+	UpdateProgressionUI();
 }
 
 // Returns difficultyMultiplier
@@ -499,4 +451,23 @@ float UPSWorldSubsystem::GetDifficultyMultiplier()
 	}
 
 	return FoundDifficulty ? *FoundDifficulty : DefaultDifficulty;
+}
+
+void UPSWorldSubsystem::UpdateProgressionUI_Implementation()
+{
+	UPSHUDComponent* PSHUDComponent = GetProgressionSystemHUDComponent();
+	if (!ensureMsgf(PSHUDComponent, TEXT("ASSERT: [%i] %hs:\n'PSHUDComponent' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+
+	UPSSpotComponent* SpotComponent = GetCurrentSpot();
+	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+
+	SpotComponent->ChangeSpotVisibilityStatus();
+	PSHUDComponent->UpdateProgressionWidgetForPlayer();
+	UpdateProgressionStarActors();
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -289,7 +289,13 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 // Returns current spot component returns null if spot is not found
 UPSSpotComponent* UPSWorldSubsystem::GetCurrentSpot() const
 {
-	FPlayerTag PlayerTag = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag();
+	APlayerCharacter* PlayerCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
+	if (!PlayerCharacter)
+	{
+		return nullptr;
+	}
+
+	const FPlayerTag& PlayerTag = PlayerCharacter->GetPlayerTag();
 	if (PSSpotComponentArrayInternal.IsEmpty() || !PlayerTag.IsValid())
 	{
 		return nullptr;
@@ -383,7 +389,7 @@ void UPSWorldSubsystem::SaveDataAsync()
 	{
 		return;
 	}
-	
+
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(), SaveGameDataInternal->GetSaveSlotIndex());
 }
 
@@ -402,7 +408,7 @@ void UPSWorldSubsystem::ResetSaveGameData()
 		return;
 	}
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
-	
+
 	checkf(SaveGameDataInternal, TEXT("ERROR: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__);
 
 	for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -404,6 +404,7 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	const int32 UserIndex = UPSSaveGameData::GetSaveSlotIndex();
 
 	SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayUtilsLibrary::ResetSaveGameData(SaveGameDataInternal, SlotName, UserIndex));
+	checkf(SaveGameDataInternal, TEXT("ERROR: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__);
 
 	// load from data table
 	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
@@ -412,8 +413,6 @@ void UPSWorldSubsystem::ResetSaveGameData()
 		return;
 	}
 	UMyDataTable::GetRows(*ProgressionDataTable, ProgressionSettingsDataInternal);
-
-	checkf(SaveGameDataInternal, TEXT("ERROR: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__);
 
 	for (const TTuple<FName, FPSRowData>& Row : ProgressionSettingsDataInternal)
 	{

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -286,7 +286,7 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 	}
 }
 
-// Returns spot component by the player tag, returns null if spot is not found
+// Returns current spot component returns null if spot is not found
 UPSSpotComponent* UPSWorldSubsystem::GetCurrentSpot() const
 {
 	FPlayerTag PlayerTag = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag();

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -462,7 +462,7 @@ float UPSWorldSubsystem::GetDifficultyMultiplier()
 	return FoundDifficulty ? *FoundDifficulty : DefaultDifficulty;
 }
 
-void UPSWorldSubsystem::UpdateProgressionUI_Implementation()
+void UPSWorldSubsystem::UpdateProgressionUI()
 {
 	UPSHUDComponent* PSHUDComponent = GetProgressionSystemHUDComponent();
 	if (!ensureMsgf(PSHUDComponent, TEXT("ASSERT: [%i] %hs:\n'PSHUDComponent' is null!"), __LINE__, __FUNCTION__))

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -339,7 +339,7 @@ UPSSpotComponent* UPSWorldSubsystem::FindSpotComponentByPlayerTag(FPlayerTag Pla
 	
 	for (UPSSpotComponent* SpotComponent : PSSpotComponentArrayInternal)
 	{
-		if (SpotComponent->GetMeshChecked().GetPlayerTag() == PlayerTag)
+		if (SpotComponent && SpotComponent->GetMeshChecked().GetPlayerTag() == PlayerTag)
 		{
 			return SpotComponent;
 		}

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -214,9 +214,9 @@ void UPSWorldSubsystem::OnGameStateChanged_Implementation(ECurrentGameState Curr
 void UPSWorldSubsystem::SetFirstElementAsCurrent()
 {
 	FName FirstSaveToDiskRow = GetFirstSaveToDiskRowName();
-
+	
 	// early return if first element is not valid
-	if (FirstSaveToDiskRow.IsNone())
+	if (!ensureMsgf(!FirstSaveToDiskRow.IsNone(), TEXT("ASSERT: [%i] %s:\n'FirstSaveToDiskRow' is not valid!"), __LINE__, *FString(__FUNCTION__)))
 	{
 		return;
 	}

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -330,7 +330,7 @@ void UPSWorldSubsystem::OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectDa
 }
 
 // Returns spot component by the player tag, returns null if spot is not found
-UPSSpotComponent* UPSWorldSubsystem::GetSpotComponentByPlayerTag(FPlayerTag PlayerTag)
+UPSSpotComponent* UPSWorldSubsystem::FindSpotComponentByPlayerTag(FPlayerTag PlayerTag) const
 {
 	if (PSSpotComponentArrayInternal.IsEmpty())
 	{
@@ -440,7 +440,7 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	// Re-load a new save game object. Load game from save creates a save file if there is no such
 	LoadGameFromSave();
 
-	UPSSpotComponent* SpotComponent = GetSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
+	UPSSpotComponent* SpotComponent = FindSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
 	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
@@ -470,7 +470,7 @@ void UPSWorldSubsystem::RefreshProgressionUIElements()
 		return;
 	}
 
-	UPSSpotComponent* SpotComponent = GetSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
+	UPSSpotComponent* SpotComponent = FindSpotComponentByPlayerTag(UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter()->GetPlayerTag());
 	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -444,7 +444,7 @@ void UPSWorldSubsystem::UnlockAllLevels()
 }
 
 // Returns difficultyMultiplier
-float UPSWorldSubsystem::GetDifficultyMultiplier()
+float UPSWorldSubsystem::GetDifficultyMultiplier() const
 {
 	const TMap<EGameDifficulty, float>& DifficultyMap = UPSDataAsset::Get().GetProgressionDifficultyMultiplier();
 	constexpr float DefaultDifficulty = 0.f;

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -56,7 +56,7 @@ protected:
 
 	/** Is called when a player has been changed */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
+	void OnLocalCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
 	/** A player skeletal mesh actor */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Player Spot On Level"))

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -112,7 +112,7 @@ public:
 
 	/** Returns spot component by the player tag, returns null if spot is not found */
 	UFUNCTION(BlueprintCallable, Category="C++")
-	UPSSpotComponent* FindSpotComponentByPlayerTag(FPlayerTag PlayerTag) const;
+	UPSSpotComponent* GetCurrentSpot() const;
 
 protected:
 	/** Contains all the assets and tweaks of Progression System game feature.

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -100,11 +100,11 @@ public:
 	void UnlockAllLevels();
 
 	/** Returns difficultyMultiplier */
-	UFUNCTION(BlueprintCallable, Category="C++")
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category="C++")
 	float GetDifficultyMultiplier();
 
 	/** Returns current spot component returns null if spot is not found */
-	UFUNCTION(BlueprintCallable, Category="C++")
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category="C++")
 	UPSSpotComponent* GetCurrentSpot() const;
 
 protected:

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -101,7 +101,7 @@ public:
 
 	/** Returns difficultyMultiplier */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="C++")
-	float GetDifficultyMultiplier();
+	float GetDifficultyMultiplier() const;
 
 	/** Returns current spot component returns null if spot is not found */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category="C++")

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -199,6 +199,6 @@ protected:
 	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
 
 	/** Is called to update the stars actors and in widgets when finish to save date in save file */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void UpdateProgressionUI();
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -110,6 +110,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category="C++")
 	float GetDifficultyMultiplier();
 
+	/** Returns spot component by the player tag, returns null if spot is not found */
+	UFUNCTION(BlueprintCallable, Category="C++")
+	UPSSpotComponent* FindSpotComponentByPlayerTag(FPlayerTag PlayerTag) const;
+
 protected:
 	/** Contains all the assets and tweaks of Progression System game feature.
 	 * Note: Since Subsystem is code-only, there is config property set in BaseProgressionSystem.ini.
@@ -187,11 +191,11 @@ protected:
 	void SetFirstElementAsCurrent();
 
 	/** Updates the stars actors for a spot */
-	UFUNCTION(Blueprintable, Category="C++", meta=(BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category="C++", meta=(BlueprintProtected))
 	void UpdateProgressionActorsForSpot();
 
 	/** Spawn/add the stars actors for a spot */
-	UFUNCTION(Blueprintable, Category="C++", meta=(BlueprintProtected))
+	UFUNCTION(BlueprintCallable, Category="C++", meta=(BlueprintProtected))
 	void AddProgressionStarActors();
 
 	/**
@@ -202,14 +206,10 @@ protected:
 	void OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectData>& CreatedObjects);
 
 	/** Triggers when a spot is loaded */
-	UFUNCTION(BlueprintNativeEvent, Blueprintable, Category="C++", meta=(BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="C++", meta=(BlueprintProtected))
 	void OnSpotComponentLoad(class UPSSpotComponent* SpotComponent);
 
 	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
-
-	/** Returns spot component by the player tag, returns null if spot is not found */
-	UFUNCTION(Blueprintable, Category="C++", meta=(BlueprintProtected))
-	UPSSpotComponent* GetSpotComponentByPlayerTag(FPlayerTag PlayerTag);
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -38,9 +38,6 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "C++")
 	void SetCurrentRowByTag(FPlayerTag NewRowPlayerTag);
 
-	/** Returns previous row of progression system */
-	const FPSRowData& GetPreviousRow() const;
-
 	/* Delegate for informing row data changed */
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
 	FCurrentRowDataChanged OnCurrentRowDataChanged;
@@ -92,7 +89,7 @@ public:
 
 	/** Saves the progression to the local files */
 	UFUNCTION()
-	void SaveDataAsync() const;
+	void SaveDataAsync();
 
 	/** Removes all saved data of the Progression system and creates a new empty data */
 	UFUNCTION(BlueprintCallable, Category = "C++")
@@ -101,10 +98,6 @@ public:
 	/** Unlocks all levels of the Progression System */
 	UFUNCTION(BlueprintCallable, Category = "C++")
 	void UnlockAllLevels();
-
-	/** Is called to update the stars actors and in widgets */
-	UFUNCTION(BlueprintCallable, Category = "C++")
-	void RefreshProgressionUIElements();
 
 	/** Returns difficultyMultiplier */
 	UFUNCTION(BlueprintCallable, Category="C++")
@@ -182,21 +175,13 @@ protected:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnGameStateChanged(ECurrentGameState CurrentGameState);
 
-	/** Load game from save file or create a new one (does initial load from data table) */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
-	void LoadGameFromSave();
-
 	/** Set first element as current active */
 	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void SetFirstElementAsCurrent();
 
-	/** Updates the stars actors for a spot */
+	/** Updates the stars actors for a spot by Spawning/adding the stars actors for a spot */
 	UFUNCTION(BlueprintCallable, Category="C++", meta=(BlueprintProtected))
-	void UpdateProgressionActorsForSpot();
-
-	/** Spawn/add the stars actors for a spot */
-	UFUNCTION(BlueprintCallable, Category="C++", meta=(BlueprintProtected))
-	void AddProgressionStarActors();
+	void UpdateProgressionStarActors();
 
 	/**
 	 * Dynamically adds Star actors which representing unlocked and locked progression above the character
@@ -212,4 +197,8 @@ protected:
 	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
+
+	/** Is called to update the stars actors and in widgets when finish to save date in save file */
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void UpdateProgressionUI();
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -208,4 +208,8 @@ protected:
 	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
+
+	/** Returns spot component by the player tag, returns null if spot is not found */
+	UFUNCTION(Blueprintable, Category="C++", meta=(BlueprintProtected))
+	UPSSpotComponent* GetSpotComponentByPlayerTag(FPlayerTag PlayerTag);
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -165,7 +165,7 @@ protected:
 
 	/** Is called when a player character is ready */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
+	void OnLocalCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
 	/** Is called when a player has been changed */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -103,7 +103,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category="C++")
 	float GetDifficultyMultiplier();
 
-	/** Returns spot component by the player tag, returns null if spot is not found */
+	/** Returns current spot component returns null if spot is not found */
 	UFUNCTION(BlueprintCallable, Category="C++")
 	UPSSpotComponent* GetCurrentSpot() const;
 


### PR DESCRIPTION
fixed: 
1. [High][Bug][PS][Build] ResetProgression-cheat always crashes the game https://trello.com/c/toLh6ZOW
2. [High][Bug][PS] UnlockProgression-cheat does not update UI on Bastet  https://trello.com/c/HPzFgitj
