### PR TITLE
Migrated all logic from HUD component to MenuWidget; introduced new delegate - OnCurrentScoreChanged (#45)

### DIFF
--- a/Config/BaseProgressionSystem.ini
+++ b/Config/BaseProgressionSystem.ini
@@ -3,4 +3,4 @@ PSDataAssetInternal=/ProgressionSystem/DataAssets/DA_ProgressionSystem.DA_Progre
 
 ; Increment save file version extennsion to force users run empty save
 ; Increment whenever a major changes done with safe file structure
-SaveFileVersionExtensionInternal=0
+SaveFileVersionExtensionInternal=1

--- a/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
@@ -11,7 +11,6 @@
 #include "Data/PSTypes.h"
 #include "Data/PSSaveGameData.h"
 #include "Data/PSWorldSubsystem.h"
-#include "GameFramework/MyGameStateBase.h"
 #include "GameFramework/MyPlayerState.h"
 #include "MyUtilsLibraries/WidgetUtilsLibrary.h"
 #include "Subsystems/GlobalEventsSubsystem.h"
@@ -37,17 +36,11 @@ void UPSHUDComponent::OnInitialized_Implementation()
 	// Binds the local player state ready event to the handler
 	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
 
-	// Listen to handle input for each game state
-	BIND_ON_GAME_STATE_CHANGED(this, ThisClass::OnGameStateChanged);
-
 	// Subscribe to the event notifying changes in player type
 	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
 
 	// Save reference of this component to the world subsystem
 	UPSWorldSubsystem::Get().SetHUDComponent(this);
-
-	// Update the progression widget based on current player state
-	UpdateProgressionWidgetForPlayer();
 }
 
 // Subscribes to the end game state change notification on the player state.
@@ -106,67 +99,19 @@ void UPSHUDComponent::SavePoints(EEndGameState EndGameState)
 	SaveGameData->SavePoints(EndGameState);
 }
 
-// Listening game states changes events 
-void UPSHUDComponent::OnGameStateChanged_Implementation(ECurrentGameState CurrentGameState)
-{
-	switch (CurrentGameState)
-	{
-	case ECurrentGameState::Menu:
-		UpdateProgressionWidgetForPlayer();
-		break;
-	default: break;
-	}
-}
-
 // Listening end game states changes events (win, lose, draw) 
 void UPSHUDComponent::OnEndGameStateChanged_Implementation(EEndGameState EndGameState)
 {
 	if (EndGameState != EEndGameState::None)
 	{
 		SavePoints(EndGameState);
-		// show the stars widget at the bottom.
-		DisplayLevelUIOverlay(false); // isLevelLocked to show/hide the level blocking overlay with padlock icon at InGame state always level locked is false
-
-		UpdateProgressionWidgetForPlayer();
 	}
 }
 
 // Handle events when player type changes
 void UPSHUDComponent::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
-	UpdateProgressionWidgetForPlayer();
-}
 
-// Refresh the main menu progression widget player 
-void UPSHUDComponent::UpdateProgressionWidgetForPlayer()
-{
-	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
-	if (!SaveGameData)
-	{
-		return;
-	}
-
-	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
-	const FPSRowData& CurrenProgressionSettingsRow = UPSWorldSubsystem::Get().GetCurrentProgressionSettingsRowByName();
-	// check if empty returned Row from GetCurrentRow
-	if (!ensureMsgf(ProgressionEndGameWidgetInternal, TEXT("ASSERT: [%i] %hs:\n'ProgressionMenuWidgetInternal' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	//set updated amount of stars
-	if (CurrenSaveToDiskDataRow.CurrentLevelProgression >= CurrenProgressionSettingsRow.PointsToUnlock)
-	{
-		// set required points (stars)  to achieve for a level  
-		ProgressionEndGameWidgetInternal->AddImagesToHorizontalBox(CurrenProgressionSettingsRow.PointsToUnlock, 0, CurrenProgressionSettingsRow.PointsToUnlock);
-	}
-	else
-	{
-		// Calculate the unlocked against locked points (stars) 
-		ProgressionEndGameWidgetInternal->AddImagesToHorizontalBox(CurrenSaveToDiskDataRow.CurrentLevelProgression, CurrenProgressionSettingsRow.PointsToUnlock - CurrenSaveToDiskDataRow.CurrentLevelProgression, CurrenProgressionSettingsRow.PointsToUnlock); // Listen game state changes events 
-	}
-
-	DisplayLevelUIOverlay(CurrenSaveToDiskDataRow.IsLevelLocked);
 }
 
 //Is called when local player character is ready to guarantee that they player controller is initialized for the Widget SubSystem
@@ -185,29 +130,4 @@ void UPSHUDComponent::OnLocalCharacterReady_Implementation(APlayerCharacter* Cha
 	UPSWorldSubsystem& WorldSubsystem = UPSWorldSubsystem::Get();
 	WorldSubsystem.OnInitialize.AddUniqueDynamic(this, &ThisClass::OnInitialized);
 	WorldSubsystem.OnWorldSubSystemInitialize();
-}
-
-// Show or hide the LevelUIOverlay depends on the level lock state for current level
-// by default overlay is always displayed 
-void UPSHUDComponent::DisplayLevelUIOverlay(bool IsLevelLocked)
-{
-	if (!ensureMsgf(ProgressionEndGameWidgetInternal, TEXT("ASSERT: [%i] %hs:\n'ProgressionMenuWidgetInternal' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	if (USettingsWidget* SettingsWidget = UMyBlueprintFunctionLibrary::GetSettingsWidget())
-	{
-		const bool bShouldPlayFadeAnimation = !SettingsWidget->GetCheckboxValue(UPSDataAsset::Get().GetInstantCharacterSwitchTag());
-		if (IsLevelLocked)
-		{
-			// Level is locked show the blocking overlay
-			ProgressionMenuOverlayWidgetInternal->SetOverlayVisibility(ESlateVisibility::Visible, bShouldPlayFadeAnimation);
-		}
-		else
-		{
-			// Level is unlocked hide the blocking overlay
-			ProgressionMenuOverlayWidgetInternal->SetOverlayVisibility(ESlateVisibility::Collapsed, bShouldPlayFadeAnimation);
-		}
-	}
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -402,8 +402,10 @@ void UPSWorldSubsystem::SaveDataAsync()
 	{
 		return;
 	}
-
-	OnCurrentScoreChanged.Broadcast();
+	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = GetCurrentSaveToDiskRowByName();
+	const FPSRowData& CurrenProgressionSettingsRow = GetCurrentProgressionSettingsRowByName();
+	
+	OnCurrentScoreChanged.Broadcast(CurrenSaveToDiskDataRow, CurrenProgressionSettingsRow);
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -214,7 +214,7 @@ void UPSWorldSubsystem::OnGameStateChanged_Implementation(ECurrentGameState Curr
 void UPSWorldSubsystem::SetFirstElementAsCurrent()
 {
 	FName FirstSaveToDiskRow = GetFirstSaveToDiskRowName();
-	
+
 	// early return if first element is not valid
 	if (!ensureMsgf(!FirstSaveToDiskRow.IsNone(), TEXT("ASSERT: [%i] %s:\n'FirstSaveToDiskRow' is not valid!"), __LINE__, *FString(__FUNCTION__)))
 	{
@@ -227,6 +227,15 @@ void UPSWorldSubsystem::SetFirstElementAsCurrent()
 
 	CurrentRowNameInternal = FirstSaveToDiskRow;
 	SaveGameDataInternal->UnlockLevelByName(CurrentRowNameInternal);
+	
+	APlayerCharacter* PlayerCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
+
+	if (!ensureMsgf(PlayerCharacter, TEXT("ASSERT: [%i] %s:\n'PlayerCharacter' is not valid!"), __LINE__, *FString(__FUNCTION__)))
+	{
+		return;
+	}
+	const FPlayerTag& PlayerTag = PlayerCharacter->GetPlayerTag();
+	SetCurrentRowByTag(PlayerTag);
 	SaveDataAsync();
 }
 
@@ -394,6 +403,7 @@ void UPSWorldSubsystem::SaveDataAsync()
 		return;
 	}
 
+	OnProgressionUpdate.Broadcast();
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
 
@@ -421,14 +431,8 @@ void UPSWorldSubsystem::ResetSaveGameData()
 
 	// Re-load save game object. Load game from save file or if there is no such creates a new one
 	SetFirstElementAsCurrent();
+	
 	UpdateProgressionUI();
-
-	const APlayerCharacter* LocalCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
-	if (!ensureMsgf(LocalCharacter, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-	SetCurrentRowByTag(LocalCharacter->GetPlayerTag());
 }
 
 // Unlocks all levels of the Progression System
@@ -439,6 +443,14 @@ void UPSWorldSubsystem::UnlockAllLevels()
 		return;
 	}
 	SaveGameDataInternal->UnlockAllLevels();
+	APlayerCharacter* PlayerCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
+
+	if (!ensureMsgf(PlayerCharacter, TEXT("ASSERT: [%i] %s:\n'PlayerCharacter' is not valid!"), __LINE__, *FString(__FUNCTION__)))
+	{
+		return;
+	}
+	const FPlayerTag& PlayerTag = PlayerCharacter->GetPlayerTag();
+	SetCurrentRowByTag(PlayerTag);
 	SaveDataAsync();
 	UpdateProgressionUI();
 }
@@ -477,6 +489,5 @@ void UPSWorldSubsystem::UpdateProgressionUI()
 	}
 
 	SpotComponent->ChangeSpotVisibilityStatus();
-	PSHUDComponent->UpdateProgressionWidgetForPlayer();
 	UpdateProgressionStarActors();
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -403,7 +403,7 @@ void UPSWorldSubsystem::SaveDataAsync()
 		return;
 	}
 
-	OnProgressionUpdate.Broadcast();
+	OnCurrentScoreChanged.Broadcast();
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -169,12 +169,6 @@ void UPSEndGameWidget::UpdateStarProgressBarValue(const FPoolObjectData& Created
 // Updates the progression menu widget when player changed
 void UPSEndGameWidget::OnCurrentScoreChanged_Implementation(const FPSSaveToDiskData& CurrenSaveToDiskDataRow, const FPSRowData& CurrenProgressionSettingsRow)
 {
-	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
-	if (!SaveGameData)
-	{
-		return;
-	}
-
 	//set updated amount of stars
 	if (CurrenSaveToDiskDataRow.CurrentLevelProgression >= CurrenProgressionSettingsRow.PointsToUnlock)
 	{

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -11,6 +11,8 @@
 #include "PoolManagerSubsystem.h"
 #include "PoolManagerTypes.h"
 #include "Components/StaticMeshComponent.h"
+#include "Data/PSTypes.h"
+#include "Data/PSWorldSubsystem.h"
 #include "Engine/CurveTable.h"
 #include "GameFramework/MyGameStateBase.h"
 #include "GameFramework/MyPlayerState.h"
@@ -33,6 +35,9 @@ void UPSEndGameWidget::NativeConstruct()
 
 	// Binds the local player state ready event to the handler
 	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
+
+	UPSWorldSubsystem& WorldSubsystem = UPSWorldSubsystem::Get();
+	WorldSubsystem.OnProgressionUpdate.AddUniqueDynamic(this, &ThisClass::UpdateProgressionWidgetForPlayer);
 }
 
 // Called when the end game state was changed to toggle progression widget visibility
@@ -159,4 +164,29 @@ void UPSEndGameWidget::UpdateStarProgressBarValue(const FPoolObjectData& Created
 {
 	UPSStarWidget& SpawnedWidget = CreatedData.GetChecked<UPSStarWidget>();
 	SpawnedWidget.UpdateProgressionBarPercentage(NewProgressBarValue);
+}
+
+// Updates the progression menu widget when player changed
+void UPSEndGameWidget::UpdateProgressionWidgetForPlayer()
+{
+	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
+	if (!SaveGameData)
+	{
+		return;
+	}
+
+	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
+	const FPSRowData& CurrenProgressionSettingsRow = UPSWorldSubsystem::Get().GetCurrentProgressionSettingsRowByName();
+
+	//set updated amount of stars
+	if (CurrenSaveToDiskDataRow.CurrentLevelProgression >= CurrenProgressionSettingsRow.PointsToUnlock)
+	{
+		// set required points (stars)  to achieve for a level  
+		AddImagesToHorizontalBox(CurrenProgressionSettingsRow.PointsToUnlock, 0, CurrenProgressionSettingsRow.PointsToUnlock);
+	}
+	else
+	{
+		// Calculate the unlocked against locked points (stars) 
+		AddImagesToHorizontalBox(CurrenSaveToDiskDataRow.CurrentLevelProgression, CurrenProgressionSettingsRow.PointsToUnlock - CurrenSaveToDiskDataRow.CurrentLevelProgression, CurrenProgressionSettingsRow.PointsToUnlock); // Listen game state changes events 
+	}
 }

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -167,7 +167,7 @@ void UPSEndGameWidget::UpdateStarProgressBarValue(const FPoolObjectData& Created
 }
 
 // Updates the progression menu widget when player changed
-void UPSEndGameWidget::OnCurrentScoreChanged()
+void UPSEndGameWidget::OnCurrentScoreChanged_Implementation()
 {
 	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
 	if (!SaveGameData)

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -37,7 +37,7 @@ void UPSEndGameWidget::NativeConstruct()
 	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
 
 	UPSWorldSubsystem& WorldSubsystem = UPSWorldSubsystem::Get();
-	WorldSubsystem.OnProgressionUpdate.AddUniqueDynamic(this, &ThisClass::UpdateProgressionWidgetForPlayer);
+	WorldSubsystem.OnCurrentScoreChanged.AddUniqueDynamic(this, &ThisClass::UpdateProgressionWidgetForPlayer);
 }
 
 // Called when the end game state was changed to toggle progression widget visibility

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -37,7 +37,7 @@ void UPSEndGameWidget::NativeConstruct()
 	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
 
 	UPSWorldSubsystem& WorldSubsystem = UPSWorldSubsystem::Get();
-	WorldSubsystem.OnCurrentScoreChanged.AddUniqueDynamic(this, &ThisClass::UpdateProgressionWidgetForPlayer);
+	WorldSubsystem.OnCurrentScoreChanged.AddUniqueDynamic(this, &ThisClass::OnCurrentScoreChanged);
 }
 
 // Called when the end game state was changed to toggle progression widget visibility
@@ -167,7 +167,7 @@ void UPSEndGameWidget::UpdateStarProgressBarValue(const FPoolObjectData& Created
 }
 
 // Updates the progression menu widget when player changed
-void UPSEndGameWidget::UpdateProgressionWidgetForPlayer()
+void UPSEndGameWidget::OnCurrentScoreChanged()
 {
 	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
 	if (!SaveGameData)

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -167,16 +167,13 @@ void UPSEndGameWidget::UpdateStarProgressBarValue(const FPoolObjectData& Created
 }
 
 // Updates the progression menu widget when player changed
-void UPSEndGameWidget::OnCurrentScoreChanged_Implementation()
+void UPSEndGameWidget::OnCurrentScoreChanged_Implementation(const FPSSaveToDiskData& CurrenSaveToDiskDataRow, const FPSRowData& CurrenProgressionSettingsRow)
 {
 	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
 	if (!SaveGameData)
 	{
 		return;
 	}
-
-	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
-	const FPSRowData& CurrenProgressionSettingsRow = UPSWorldSubsystem::Get().GetCurrentProgressionSettingsRowByName();
 
 	//set updated amount of stars
 	if (CurrenSaveToDiskDataRow.CurrentLevelProgression >= CurrenProgressionSettingsRow.PointsToUnlock)

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
@@ -135,19 +135,12 @@ void UPSOverlayWidget::DisplayLevelUIOverlay()
 {
 	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
 	const bool IsLevelLocked = CurrenSaveToDiskDataRow.IsLevelLocked;
-	
+
 	if (USettingsWidget* SettingsWidget = UMyBlueprintFunctionLibrary::GetSettingsWidget())
 	{
 		const bool bShouldPlayFadeAnimation = !SettingsWidget->GetCheckboxValue(UPSDataAsset::Get().GetInstantCharacterSwitchTag());
-		if (IsLevelLocked)
-		{
-			// Level is locked show the blocking overlay
-			SetOverlayVisibility(ESlateVisibility::Visible, bShouldPlayFadeAnimation);
-		}
-		else
-		{
-			// Level is unlocked hide the blocking overlay
-			SetOverlayVisibility(ESlateVisibility::Collapsed, bShouldPlayFadeAnimation);
-		}
+
+		const ESlateVisibility OverlayVisibility = IsLevelLocked ? ESlateVisibility::Visible : ESlateVisibility::Collapsed;
+		SetOverlayVisibility(OverlayVisibility, bShouldPlayFadeAnimation);
 	}
 }

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
@@ -80,7 +80,7 @@ void UPSOverlayWidget::NativeConstruct()
 	SetVisibility(ESlateVisibility::Collapsed);
 
 	// Subscribe to the event notifying changes in player type
-	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
+	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnCurrentRowDataChanged);
 }
 
 // Play the overlay elements fade-in/fade-out animation. Uses the internal FadeCurveFloatInternal initialized in NativeConstruct
@@ -117,8 +117,8 @@ void UPSOverlayWidget::TickPlayFadeOverlayAnimation()
 	}
 }
 
-// Is called when a player has been changed 
-void UPSOverlayWidget::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
+// When a character has been changed current active progression row also changes
+void UPSOverlayWidget::OnCurrentRowDataChanged_Implementation(FPlayerTag PlayerTag)
 {
 	DisplayLevelUIOverlay();
 }

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
@@ -7,6 +7,9 @@
 #include "Curves/CurveFloat.h"
 #include "Data/PSDataAsset.h"
 #include "Components/Overlay.h"
+#include "Data/PSWorldSubsystem.h"
+#include "UI/SettingsWidget.h"
+#include "UtilityLibraries/MyBlueprintFunctionLibrary.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(PSOverlayWidget)
 
@@ -75,6 +78,9 @@ void UPSOverlayWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 	SetVisibility(ESlateVisibility::Collapsed);
+
+	// Subscribe to the event notifying changes in player type
+	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
 }
 
 // Play the overlay elements fade-in/fade-out animation. Uses the internal FadeCurveFloatInternal initialized in NativeConstruct
@@ -111,8 +117,37 @@ void UPSOverlayWidget::TickPlayFadeOverlayAnimation()
 	}
 }
 
+// Is called when a player has been changed 
+void UPSOverlayWidget::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
+{
+	DisplayLevelUIOverlay();
+}
+
 void UPSOverlayWidget::SetOverlayItemsVisibility(ESlateVisibility VisibilitySlate)
 {
 	// Level is unlocked hide the blocking overlay
 	SetVisibility(VisibilitySlate);
+}
+
+// Show or hide the LevelUIOverlay depends on the level lock state for current level
+// by default overlay is always displayed 
+void UPSOverlayWidget::DisplayLevelUIOverlay()
+{
+	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
+	const bool IsLevelLocked = CurrenSaveToDiskDataRow.IsLevelLocked;
+	
+	if (USettingsWidget* SettingsWidget = UMyBlueprintFunctionLibrary::GetSettingsWidget())
+	{
+		const bool bShouldPlayFadeAnimation = !SettingsWidget->GetCheckboxValue(UPSDataAsset::Get().GetInstantCharacterSwitchTag());
+		if (IsLevelLocked)
+		{
+			// Level is locked show the blocking overlay
+			SetOverlayVisibility(ESlateVisibility::Visible, bShouldPlayFadeAnimation);
+		}
+		else
+		{
+			// Level is unlocked hide the blocking overlay
+			SetOverlayVisibility(ESlateVisibility::Collapsed, bShouldPlayFadeAnimation);
+		}
+	}
 }

--- a/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
@@ -26,10 +26,6 @@ public:
 	UFUNCTION(BlueprintCallable, Category="C++")
 	void SavePoints(EEndGameState EndGameState);
 	
-	/** Updates the progression menu widget when player changed */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
-	void UpdateProgressionWidgetForPlayer();
-	
 	/*********************************************************************************************
 	* Protected properties
 	********************************************************************************************* */
@@ -61,10 +57,6 @@ protected:
 	/** Clears all transient data created by this component. */
 	virtual void OnUnregister() override;
 
-	/** Called when the current game state was changed. */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnGameStateChanged(ECurrentGameState CurrentGameState);
-
 	/** Called when the end game state was changed. */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnEndGameStateChanged(EEndGameState EndGameState);
@@ -76,8 +68,4 @@ protected:
 	/** Is called when local player character is ready to guarantee that they player controller is initialized for the Widget SubSystem */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnLocalCharacterReady(class APlayerCharacter* Character, int32 CharacterID);
-
-	/** Show locked level ui overlay */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
-	void DisplayLevelUIOverlay(bool IsLevelLocked);
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -23,6 +23,8 @@ public:
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnInitialize);
 
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnProgressionUpdate);
+	
 	/** Returns this Subsystem, is checked and will crash if it can't be obtained.*/
 	static UPSWorldSubsystem& Get();
 	static UPSWorldSubsystem& Get(const UObject& WorldContextObject);
@@ -46,6 +48,10 @@ public:
 	/* Delegate for informing save game file is loaded/created if empty */
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
 	FPSOnInitialize OnInitialize;
+
+	/* Delegate for informing save game file is loaded/created if empty */
+	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
+	FPSOnProgressionUpdate OnProgressionUpdate;
 
 	/** Returns the data asset that contains all the assets of Progression System game feature.
 	 * @see UPSWorldSubsystem::PSDataAssetInternal. */

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -23,7 +23,7 @@ public:
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnInitialize);
 
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnCurrentScoreChanged);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FPSOnCurrentScoreChanged, const FPSSaveToDiskData&, CurrenSaveToDiskDataRow, const FPSRowData&, CurrenProgressionSettingsRow);
 	
 	/** Returns this Subsystem, is checked and will crash if it can't be obtained.*/
 	static UPSWorldSubsystem& Get();

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -23,7 +23,7 @@ public:
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnInitialize);
 
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnProgressionUpdate);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnCurrentScoreChanged);
 	
 	/** Returns this Subsystem, is checked and will crash if it can't be obtained.*/
 	static UPSWorldSubsystem& Get();
@@ -51,7 +51,7 @@ public:
 
 	/* Delegate for informing save game file is loaded/created if empty */
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
-	FPSOnProgressionUpdate OnProgressionUpdate;
+	FPSOnCurrentScoreChanged OnCurrentScoreChanged;
 
 	/** Returns the data asset that contains all the assets of Progression System game feature.
 	 * @see UPSWorldSubsystem::PSDataAssetInternal. */

--- a/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
+++ b/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
@@ -82,5 +82,5 @@ protected:
 
 	/** Updates the progression menu widget when player changed */
 	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
-	void UpdateProgressionWidgetForPlayer();
+	void OnCurrentScoreChanged();
 };

--- a/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
+++ b/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
@@ -81,6 +81,6 @@ protected:
 	void UpdateStarProgressBarValue(const FPoolObjectData& CreatedData, float NewProgressBarValue);
 
 	/** Updates the progression menu widget when player changed */
-	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, Category= "C++", meta = (BlueprintProtected))
 	void OnCurrentScoreChanged();
 };

--- a/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
+++ b/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
@@ -79,4 +79,8 @@ protected:
 	 */
 	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void UpdateStarProgressBarValue(const FPoolObjectData& CreatedData, float NewProgressBarValue);
+
+	/** Updates the progression menu widget when player changed */
+	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	void UpdateProgressionWidgetForPlayer();
 };

--- a/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
+++ b/Source/ProgressionSystemRuntime/Public/Widgets/PSEndGameWidget.h
@@ -82,5 +82,5 @@ protected:
 
 	/** Updates the progression menu widget when player changed */
 	UFUNCTION(BlueprintNativeEvent, Category= "C++", meta = (BlueprintProtected))
-	void OnCurrentScoreChanged();
+	void OnCurrentScoreChanged(const FPSSaveToDiskData& CurrenSaveToDiskDataRow, const FPSRowData& CurrenProgressionSettingsRow);
 };

--- a/Source/ProgressionSystemRuntime/Public/Widgets/PSOverlayWidget.h
+++ b/Source/ProgressionSystemRuntime/Public/Widgets/PSOverlayWidget.h
@@ -39,9 +39,9 @@ protected:
 	UFUNCTION(BlueprintCallable, Category="C++", meta=(BlueprintProtected))
 	void TickPlayFadeOverlayAnimation();
 
-	/** Is called when a player has been changed */
+	/** When a character has been changed current active progression row also changes */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
+	void OnCurrentRowDataChanged(FPlayerTag PlayerTag);
 	
 	/**
 	* Sets the visibility of the background overlay and lock icon.

--- a/Source/ProgressionSystemRuntime/Public/Widgets/PSOverlayWidget.h
+++ b/Source/ProgressionSystemRuntime/Public/Widgets/PSOverlayWidget.h
@@ -39,6 +39,10 @@ protected:
 	UFUNCTION(BlueprintCallable, Category="C++", meta=(BlueprintProtected))
 	void TickPlayFadeOverlayAnimation();
 
+	/** Is called when a player has been changed */
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
+	
 	/**
 	* Sets the visibility of the background overlay and lock icon.
 	* @param VisibilitySlate The visibility state (e.g., Visible, Collapsed) to apply to the overlay and icon.
@@ -61,4 +65,8 @@ protected:
 	/** Current overlay widget fade state. */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, AdvancedDisplay, Category = "C++", meta = (BlueprintProtected, DisplayName = "Overlay Widget Fade State"))
 	EPSOverlayWidgetFadeState OverlayWidgetFadeStateInternal = EPSOverlayWidgetFadeState::None;
+
+	/** Show locked level ui overlay */
+	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
+	void DisplayLevelUIOverlay();
 };


### PR DESCRIPTION
https://trello.com/c/6FcOwdnx/869-ps-refactoring-migrate-all-logic-from-hud-component-to-menuwidget

- Introduced a new delegate - OnProgressionUpdate which is called whenever progression is modified
 ![image](https://github.com/user-attachments/assets/82889b36-2605-4f72-96bf-1192fe4df34c)
- Removed all logic from the hud component for managing widget state. 
- Widgets now listening OnProgressionUpdate and OnCurrentRowDataChanged to react respectfully (refresh the stars, or show/hide overlay) 
 ![image](https://github.com/user-attachments/assets/2c44d8a0-f33a-4f1a-86ff-c3cb998ae36d)
![image](https://github.com/user-attachments/assets/62a56719-fa69-4487-8b79-81b56c2acff4)

