### PR TITLE
Refactoring PSSpotComponent, PSWorldSubsystem

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
@@ -37,7 +37,7 @@ void UPSHUDComponent::OnInitialized_Implementation()
 	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
 
 	// Subscribe to the event notifying changes in player type
-	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
+	UPSWorldSubsystem::Get().OnCurrentActiveSaveRowChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
 
 	// Save reference of this component to the world subsystem
 	UPSWorldSubsystem::Get().SetHUDComponent(this);

--- a/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
@@ -26,24 +26,18 @@ UPSSpotComponent::UPSSpotComponent()
 // Called when progression module ready
 void UPSSpotComponent::OnInitialized_Implementation()
 {
-	// Ensure the component's mesh is properly assigned and not null.
-	PlayerSpotOnLevelInternal = GetMeshChecked();
-
-	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnPlayerTypeChanged);
-	// Subscribe events on player type changed and Character spawned
-	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnLocalCharacterReady);
-
-	ChangeSpotVisibilityStatus();
-
+	UPSWorldSubsystem& WorldSubsystem = UPSWorldSubsystem::Get();
+	WorldSubsystem.OnCurrentActiveSaveRowChanged.AddUniqueDynamic(this, &ThisClass::OnCurrentActiveSaveRowChanged);
 	// Save reference of this component to the world subsystem
-	UPSWorldSubsystem::Get().RegisterSpotComponent(this);
+	WorldSubsystem.RegisterSpotComponent(this);
 }
 
 // Called when the game starts
 void UPSSpotComponent::BeginPlay()
 {
 	Super::BeginPlay();
-	UPSWorldSubsystem::Get().OnInitialize.AddDynamic(this, &ThisClass::OnInitialized);
+	UPSWorldSubsystem& WorldSubsystem = UPSWorldSubsystem::Get();
+	WorldSubsystem.OnInitialize.AddDynamic(this, &ThisClass::OnInitialized);
 }
 
 // Clears all transient data created by this component.
@@ -51,13 +45,19 @@ void UPSSpotComponent::OnUnregister()
 {
 	// reset back to initial state. By default, the spot is unlocked 
 	constexpr bool bSpotUnlocked = true;
-	if (PlayerSpotOnLevelInternal)
-	{
-		PlayerSpotOnLevelInternal->SetActive(bSpotUnlocked);
-		PlayerSpotOnLevelInternal = nullptr;
-	}
+	GetMeshChecked().SetActive(bSpotUnlocked);
 
 	Super::OnUnregister();
+}
+
+// Updates the progression menu widget when player changed
+void UPSSpotComponent::OnCurrentActiveSaveRowChanged_Implementation(const FPlayerTag PlayerTag)
+{
+	UMySkeletalMeshComponent& Mesh = GetMeshChecked();
+	if (Mesh.GetPlayerTag() == PlayerTag)
+	{
+		ChangeSpotVisibilityStatus(&Mesh);
+	}
 }
 
 // Returns the Skeletal Mesh of the Bomber character
@@ -74,37 +74,10 @@ UMySkeletalMeshComponent& UPSSpotComponent::GetMeshChecked() const
 	return *Mesh;
 }
 
-// Is called when a player has been changed
-void UPSSpotComponent::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
-{
-	UMySkeletalMeshComponent& Mesh = GetMeshChecked();
-	if (Mesh.GetPlayerTag() == PlayerTag)
-	{
-		PlayerSpotOnLevelInternal = Mesh;
-		ChangeSpotVisibilityStatus();
-
-		// Save reference of this component to the world subsystem
-		UPSWorldSubsystem::Get().SetCurrentSpotComponent(this);
-	}
-}
-
-//  Is called when a player has been changed 
-void UPSSpotComponent::OnLocalCharacterReady_Implementation(APlayerCharacter* PlayerCharacter, int32 CharacterID)
-{
-	if (PlayerCharacter->GetPlayerTag() == GetMeshChecked().GetPlayerTag())
-	{
-		PlayerSpotOnLevelInternal = GetMeshChecked();
-		OnSpotComponentReady.Broadcast(this);
-	}
-}
-
-// Locks the player spot when progression for level achieved 
-void UPSSpotComponent::ChangeSpotVisibilityStatus()
+// Changes the player spot depends on current level state 
+void UPSSpotComponent::ChangeSpotVisibilityStatus(UMySkeletalMeshComponent* Mesh)
 {
 	// Locks and unlocks the spot depends on the current level progression status
-	if (PlayerSpotOnLevelInternal)
-	{
-		FPSSaveToDiskData SaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
-		PlayerSpotOnLevelInternal->SetActive(!SaveToDiskDataRow.IsLevelLocked);
-	}
+	FPSSaveToDiskData SaveToDiskDataRow = UPSWorldSubsystem::Get().GetCurrentSaveToDiskRowByName();
+	Mesh->SetActive(!SaveToDiskDataRow.IsLevelLocked);
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -56,7 +56,7 @@ void UPSWorldSubsystem::SetCurrentRowByTag(FPlayerTag NewRowPlayerTag)
 		if (RowData.Character == NewRowPlayerTag)
 		{
 			CurrentRowNameInternal = KeyValue.Key;
-			OnCurrentRowDataChanged.Broadcast(NewRowPlayerTag);
+			OnCurrentActiveSaveRowChanged.Broadcast(NewRowPlayerTag);
 			return; // Exit immediately after finding the match
 		}
 	}
@@ -110,23 +110,13 @@ void UPSWorldSubsystem::SetHUDComponent(UPSHUDComponent* MyHUDComponent)
 }
 
 // Set the progression system spot component
-void UPSWorldSubsystem::RegisterSpotComponent(UPSSpotComponent* MyHUDComponent)
+void UPSWorldSubsystem::RegisterSpotComponent(UPSSpotComponent* MySpotComponent)
 {
-	if (!ensureMsgf(MyHUDComponent, TEXT("ASSERT: [%i] %hs:\n'MyHUDComponent' is null!"), __LINE__, __FUNCTION__))
+	if (!ensureMsgf(MySpotComponent, TEXT("ASSERT: [%i] %hs:\n'MyHUDComponent' is null!"), __LINE__, __FUNCTION__))
 	{
 		return;
 	}
-	PSSpotComponentArrayInternal.AddUnique(MyHUDComponent);
-	MyHUDComponent->OnSpotComponentReady.AddDynamic(this, &UPSWorldSubsystem::OnSpotComponentLoad);
-}
-
-void UPSWorldSubsystem::SetCurrentSpotComponent(UPSSpotComponent* MyHUDComponent)
-{
-	if (!ensureMsgf(MyHUDComponent, TEXT("ASSERT: [%i] %hs:\n'MyHUDComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-	PSCurrentSpotComponentInternal = MyHUDComponent;
+	PSSpotComponentArrayInternal.AddUnique(MySpotComponent);
 }
 
 // Called when progression module ready
@@ -182,15 +172,7 @@ void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 	// todo refactor: in SetCurrentRowByTag function on broadcast OnCurrentRowDataChanged create a function which will
 	// perform all logic after this function call
 	SetCurrentRowByTag(PlayerTag);
-
-	for (UPSSpotComponent* SpotComponent : PSSpotComponentArrayInternal)
-	{
-		if (SpotComponent->GetMeshChecked().GetPlayerTag() == PlayerTag)
-		{
-			PSCurrentSpotComponentInternal = SpotComponent;
-			UpdateProgressionStarActors();
-		}
-	}
+	UpdateProgressionStarActors();
 }
 
 // Called when the current game state was changed
@@ -227,7 +209,7 @@ void UPSWorldSubsystem::SetFirstElementAsCurrent()
 
 	CurrentRowNameInternal = FirstSaveToDiskRow;
 	SaveGameDataInternal->UnlockLevelByName(CurrentRowNameInternal);
-	
+
 	APlayerCharacter* PlayerCharacter = UMyBlueprintFunctionLibrary::GetLocalPlayerCharacter();
 
 	if (!ensureMsgf(PlayerCharacter, TEXT("ASSERT: [%i] %s:\n'PlayerCharacter' is not valid!"), __LINE__, *FString(__FUNCTION__)))
@@ -324,17 +306,6 @@ UPSSpotComponent* UPSWorldSubsystem::GetCurrentSpot() const
 	return nullptr;
 }
 
-// Triggers when a spot is loaded
-void UPSWorldSubsystem::OnSpotComponentLoad_Implementation(UPSSpotComponent* SpotComponent)
-{
-	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %s:\n'SpotComponent' is not valid!"), __LINE__, *FString(__FUNCTION__)))
-	{
-		return;
-	}
-
-	PSCurrentSpotComponentInternal = SpotComponent;
-}
-
 // Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load.
 void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FString& SlotName, int32 UserIndex, USaveGame* SaveGame)
 {
@@ -385,7 +356,6 @@ void UPSWorldSubsystem::PerformCleanUp()
 	UMyPrimaryDataAsset::ResetDataAsset(PSDataAssetInternal);
 	PSHUDComponentInternal = nullptr;
 	PSSpotComponentArrayInternal.Empty();
-	PSCurrentSpotComponentInternal = nullptr;
 
 	// Saves clean up 
 	if (SaveGameDataInternal)
@@ -404,7 +374,7 @@ void UPSWorldSubsystem::SaveDataAsync()
 	}
 	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = GetCurrentSaveToDiskRowByName();
 	const FPSRowData& CurrenProgressionSettingsRow = GetCurrentProgressionSettingsRowByName();
-	
+
 	OnCurrentScoreChanged.Broadcast(CurrenSaveToDiskDataRow, CurrenProgressionSettingsRow);
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
@@ -433,8 +403,7 @@ void UPSWorldSubsystem::ResetSaveGameData()
 
 	// Re-load save game object. Load game from save file or if there is no such creates a new one
 	SetFirstElementAsCurrent();
-	
-	UpdateProgressionUI();
+	UpdateProgressionStarActors();
 }
 
 // Unlocks all levels of the Progression System
@@ -454,7 +423,7 @@ void UPSWorldSubsystem::UnlockAllLevels()
 	const FPlayerTag& PlayerTag = PlayerCharacter->GetPlayerTag();
 	SetCurrentRowByTag(PlayerTag);
 	SaveDataAsync();
-	UpdateProgressionUI();
+	UpdateProgressionStarActors();
 }
 
 // Returns difficultyMultiplier
@@ -474,22 +443,4 @@ float UPSWorldSubsystem::GetDifficultyMultiplier() const
 	}
 
 	return FoundDifficulty ? *FoundDifficulty : DefaultDifficulty;
-}
-
-void UPSWorldSubsystem::UpdateProgressionUI()
-{
-	UPSHUDComponent* PSHUDComponent = GetProgressionSystemHUDComponent();
-	if (!ensureMsgf(PSHUDComponent, TEXT("ASSERT: [%i] %hs:\n'PSHUDComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	UPSSpotComponent* SpotComponent = GetCurrentSpot();
-	if (!ensureMsgf(SpotComponent, TEXT("ASSERT: [%i] %hs:\n'SpotComponent' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-
-	SpotComponent->ChangeSpotVisibilityStatus();
-	UpdateProgressionStarActors();
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -57,6 +57,7 @@ void UPSWorldSubsystem::SetCurrentRowByTag(FPlayerTag NewRowPlayerTag)
 		{
 			CurrentRowNameInternal = KeyValue.Key;
 			OnCurrentActiveSaveRowChanged.Broadcast(NewRowPlayerTag);
+			UpdateProgressionStarActors();
 			return; // Exit immediately after finding the match
 		}
 	}
@@ -130,9 +131,6 @@ void UPSWorldSubsystem::OnInitialized_Implementation()
 
 	// Subscribe events on player type changed and Character spawned
 	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnLocalCharacterReady);
-
-	// Listen to handle input for each game state
-	BIND_ON_GAME_STATE_CHANGED(this, ThisClass::OnGameStateChanged);
 }
 
 // Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors 
@@ -170,24 +168,6 @@ void UPSWorldSubsystem::OnLocalCharacterReady_Implementation(APlayerCharacter* P
 void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
 	SetCurrentRowByTag(PlayerTag);
-	UpdateProgressionStarActors();
-}
-
-// Called when the current game state was changed
-void UPSWorldSubsystem::OnGameStateChanged_Implementation(ECurrentGameState CurrentGameState)
-{
-	switch (CurrentGameState)
-	{
-	case ECurrentGameState::Menu:
-		// refresh 3D Stars actors
-		UpdateProgressionStarActors();
-		break;
-	case ECurrentGameState::GameStarting:
-		// Show Progression Menu widget in Main Menu
-		break;
-	default:
-		break;
-	}
 }
 
 // Always set first levels as unlocked on begin play
@@ -401,7 +381,6 @@ void UPSWorldSubsystem::ResetSaveGameData()
 
 	// Re-load save game object. Load game from save file or if there is no such creates a new one
 	SetFirstElementAsCurrent();
-	UpdateProgressionStarActors();
 }
 
 // Unlocks all levels of the Progression System
@@ -421,7 +400,6 @@ void UPSWorldSubsystem::UnlockAllLevels()
 	const FPlayerTag& PlayerTag = PlayerCharacter->GetPlayerTag();
 	SetCurrentRowByTag(PlayerTag);
 	SaveDataAsync();
-	UpdateProgressionStarActors();
 }
 
 // Returns difficultyMultiplier

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -169,8 +169,6 @@ void UPSWorldSubsystem::OnLocalCharacterReady_Implementation(APlayerCharacter* P
 // Is called when a player has been changed
 void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
-	// todo refactor: in SetCurrentRowByTag function on broadcast OnCurrentRowDataChanged create a function which will
-	// perform all logic after this function call
 	SetCurrentRowByTag(PlayerTag);
 	UpdateProgressionStarActors();
 }

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSOverlayWidget.cpp
@@ -80,7 +80,7 @@ void UPSOverlayWidget::NativeConstruct()
 	SetVisibility(ESlateVisibility::Collapsed);
 
 	// Subscribe to the event notifying changes in player type
-	UPSWorldSubsystem::Get().OnCurrentRowDataChanged.AddDynamic(this, &ThisClass::OnCurrentRowDataChanged);
+	UPSWorldSubsystem::Get().OnCurrentActiveSaveRowChanged.AddDynamic(this, &ThisClass::OnCurrentRowDataChanged);
 }
 
 // Play the overlay elements fade-in/fade-out animation. Uses the internal FadeCurveFloatInternal initialized in NativeConstruct

--- a/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSSpotComponent.h
@@ -16,8 +16,6 @@ class PROGRESSIONSYSTEMRUNTIME_API UPSSpotComponent : public UActorComponent
 	GENERATED_BODY()
 
 public:
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FPSSpotComponent, UPSSpotComponent*, SpotComponent);
-
 	// Sets default values for this component's properties
 	UPSSpotComponent();
 
@@ -26,39 +24,23 @@ public:
 	class UMySkeletalMeshComponent* GetMySkeletalMeshComponent() const;
 	class UMySkeletalMeshComponent& GetMeshChecked() const;
 
-	/** Returns a Player's Spot On level (skeletal mesh component) */
-	UFUNCTION(BlueprintPure, Category = "C++")
-	FORCEINLINE class UMySkeletalMeshComponent* GetPlayerSpotOnLevel() const { return PlayerSpotOnLevelInternal; }
-
-	/* Delegate for informing about loading spot component */
-	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
-	FPSSpotComponent OnSpotComponentReady;
-
-	/** Locks the player spot when progression for level achieved */
+	/** Changes the player spot depends on current level state  */
 	UFUNCTION(BlueprintCallable, Category= "C++")
-	void ChangeSpotVisibilityStatus();
+	void ChangeSpotVisibilityStatus(UMySkeletalMeshComponent* Mesh);
 
 protected:
 	/** Called when progression module ready
 	 * Once the save file is loaded it activates the functionality of this class */
-	UFUNCTION(BlueprintNativeEvent,BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnInitialized();
-	
+
 	// Called when the game starts
 	virtual void BeginPlay() override;
 
 	/** Clears all transient data created by this component. */
 	virtual void OnUnregister() override;
 
-	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
-
-	/** Is called when a player has been changed */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnLocalCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
-
-	/** A player skeletal mesh actor */
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Player Spot On Level"))
-	TObjectPtr<UMySkeletalMeshComponent> PlayerSpotOnLevelInternal = nullptr;
+	/** Updates the progression menu widget when player changed */
+	UFUNCTION(BlueprintNativeEvent, Category= "C++", meta = (BlueprintProtected))
+	void OnCurrentActiveSaveRowChanged(const FPlayerTag PlayerTag);
 };

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -183,10 +183,6 @@ protected:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
-	/** Called when the current game state was changed. */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnGameStateChanged(ECurrentGameState CurrentGameState);
-
 	/** Set first element as current active */
 	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void SetFirstElementAsCurrent();

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -19,12 +19,12 @@ class PROGRESSIONSYSTEMRUNTIME_API UPSWorldSubsystem : public UWorldSubsystem
 	GENERATED_BODY()
 
 public:
-	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCurrentRowDataChanged, const FPlayerTag, SavedProgressionRowData);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCurrentActiveSaveRowChanged, const FPlayerTag, SavedProgressionRowData);
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FPSOnInitialize);
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FPSOnCurrentScoreChanged, const FPSSaveToDiskData&, CurrenSaveToDiskDataRow, const FPSRowData&, CurrenProgressionSettingsRow);
-	
+
 	/** Returns this Subsystem, is checked and will crash if it can't be obtained.*/
 	static UPSWorldSubsystem& Get();
 	static UPSWorldSubsystem& Get(const UObject& WorldContextObject);
@@ -41,9 +41,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "C++")
 	void SetCurrentRowByTag(FPlayerTag NewRowPlayerTag);
 
-	/* Delegate for informing row data changed */
+	/* Each level has its own row. Each row is tied to a character
+	 * Delegate is called after chosen character was changed so the active save row in save instance also changed */
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
-	FCurrentRowDataChanged OnCurrentRowDataChanged;
+	FCurrentActiveSaveRowChanged OnCurrentActiveSaveRowChanged;
 
 	/* Delegate for informing save game file is loaded/created if empty */
 	UPROPERTY(BlueprintAssignable, Transient, Category = "C++")
@@ -95,10 +96,6 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "C++")
 	void RegisterSpotComponent(class UPSSpotComponent* MyHUDComponent);
 
-	/** Set the progression system spot component */
-	UFUNCTION(BlueprintCallable, Category = "C++")
-	void SetCurrentSpotComponent(class UPSSpotComponent* MyHUDComponent);
-
 	/** Saves the progression to the local files */
 	UFUNCTION()
 	void SaveDataAsync();
@@ -141,10 +138,6 @@ protected:
 	/** Progression System Array of Spot Components */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System Spot Array"))
 	TArray<class UPSSpotComponent*> PSSpotComponentArrayInternal;
-
-	/** Progression System Spot Component reference*/
-	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, Category = "C++", meta = (BlueprintProtected, DisplayName = "Progression System Spot Component"))
-	TObjectPtr<class UPSSpotComponent> PSCurrentSpotComponentInternal = nullptr;
 
 	/** Store the current save game instance
 	 * Contains the FPSSaveToDiskData which has actual data from save file */
@@ -209,15 +202,7 @@ protected:
 	UFUNCTION(BlueprintCallable, Category= "C++")
 	void OnTakeActorsFromPoolCompleted(const TArray<FPoolObjectData>& CreatedObjects);
 
-	/** Triggers when a spot is loaded */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category="C++", meta=(BlueprintProtected))
-	void OnSpotComponentLoad(class UPSSpotComponent* SpotComponent);
-
 	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
-
-	/** Is called to update the stars actors and in widgets when finish to save date in save file */
-	UFUNCTION(BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void UpdateProgressionUI();
 };


### PR DESCRIPTION
PSSpotComponent:
1. Added OnCurrentActiveSaveRowChanged delegate subscription 
2. Moved logic from UPSWorldSubsystem to Changevisibility into SpotComponent
3. Removed unused spot reference and delegate which broadcast when data is set


PSWorldSubsystem:
1. Removed unused Spot reference
2. Renamed delegate for better naming 
3. Removed unused parts of code, functions, redundant calls 