### PR TITLE
[PS] Refactor: Stop adding score into total score if max starts achieved and exposed delegate on progression finished

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
@@ -33,22 +33,8 @@ UPSHUDComponent::UPSHUDComponent()
 // Called when main save game file is loaded
 void UPSHUDComponent::OnInitialized_Implementation()
 {
-	// Binds the local player state ready event to the handler
-	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
-
 	// Save reference of this component to the world subsystem
 	UPSWorldSubsystem::Get().SetHUDComponent(this);
-}
-
-// Subscribes to the end game state change notification on the player state.
-void UPSHUDComponent::OnLocalPlayerStateReady_Implementation(AMyPlayerState* PlayerState, int32 CharacterID)
-{
-	// Ensure that PlayerState is not null before subscribing to the event
-	if (!ensureMsgf(PlayerState, TEXT("ASSERT: [%i] %hs:\n'PlayerState' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-	PlayerState->OnEndGameStateChanged.AddUniqueDynamic(this, &ThisClass::OnEndGameStateChanged);
 }
 
 // Called when the game starts
@@ -80,28 +66,6 @@ void UPSHUDComponent::OnUnregister()
 	if (UGlobalEventsSubsystem* EventSubsystem = UGlobalEventsSubsystem::GetGlobalEventsSubsystem())
 	{
 		EventSubsystem->BP_OnLocalCharacterReady.RemoveAll(this);
-	}
-}
-
-// Save the progression depends on EEndGameState
-void UPSHUDComponent::SavePoints(EEndGameState EndGameState)
-{
-	// @h4rdmol to move to Subsystem instead of hud
-	const UPSSaveGameData* SaveGameInstance = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
-	if (!ensureMsgf(SaveGameInstance, TEXT("ASSERT: [%i] %hs:\n'SaveGameInstance' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
-	UPSSaveGameData* SaveGameData = UPSWorldSubsystem::Get().GetCurrentSaveGameData();
-	SaveGameData->SavePoints(EndGameState);
-}
-
-// Listening end game states changes events (win, lose, draw) 
-void UPSHUDComponent::OnEndGameStateChanged_Implementation(EEndGameState EndGameState)
-{
-	if (EndGameState != EEndGameState::None)
-	{
-		SavePoints(EndGameState);
 	}
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSSaveGameData.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSSaveGameData.cpp
@@ -3,6 +3,7 @@
 #include "Data/PSSaveGameData.h"
 
 #include "Data/PSWorldSubsystem.h"
+#include "Subsystems/GlobalEventsSubsystem.h"
 #include "UtilityLibraries/MyBlueprintFunctionLibrary.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(PSSaveGameData)
@@ -55,9 +56,15 @@ void UPSSaveGameData::SavePoints(EEndGameState EndGameState)
 		// Increase the current level's progression by the reward from the end game state
 		FName CurrentRowName = UPSWorldSubsystem::Get().GetCurrentRowName();
 		FPSSaveToDiskData* CurrentSaveToDiskDataRowRef = ProgressionSettingsRowDataInternal.Find(CurrentRowName);
-		CurrentSaveToDiskDataRowRef->CurrentLevelProgression += GetProgressionReward(EndGameState);
-
 		const FPSRowData& CurrentProgressionSettingsRowData = UPSWorldSubsystem::Get().GetCurrentProgressionSettingsRowByName();
+
+		// do nothing if max start achieved. Max stars of level is amount of point to unlock for a level
+		if (CurrentSaveToDiskDataRowRef->CurrentLevelProgression >= CurrentProgressionSettingsRowData.PointsToUnlock)
+		{
+			return;
+		}
+		
+		CurrentSaveToDiskDataRowRef->CurrentLevelProgression += GetProgressionReward(EndGameState);
 
 		// Check if the current level progression has reached or surpassed the points needed to unlock
 		if (CurrentSaveToDiskDataRowRef->CurrentLevelProgression >= CurrentProgressionSettingsRowData.PointsToUnlock)
@@ -72,9 +79,13 @@ void UPSSaveGameData::SavePoints(EEndGameState EndGameState)
 void UPSSaveGameData::NextLevelProgressionRowData()
 {
 	bool bNextRowFound = false;
-
+	
+	int32 Index = 0;
+	
 	for (const TTuple<FName, FPSSaveToDiskData>& KeyValue : ProgressionSettingsRowDataInternal)
 	{
+		Index++;
+		
 		if (bNextRowFound)
 		{
 			UnlockLevelByName(KeyValue.Key);
@@ -84,6 +95,11 @@ void UPSSaveGameData::NextLevelProgressionRowData()
 		if (KeyValue.Key == UPSWorldSubsystem::Get().GetCurrentRowName())
 		{
 			bNextRowFound = true; // Indicate that the current row has been found
+
+			if (Index == ProgressionSettingsRowDataInternal.Num())
+			{
+				UGlobalEventsSubsystem::Get().OnGameProgressionCompleted.Broadcast();
+			}
 		}
 	}
 }

--- a/Source/ProgressionSystemRuntime/Private/Data/PSSaveGameData.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSSaveGameData.cpp
@@ -63,8 +63,9 @@ void UPSSaveGameData::SavePoints(EEndGameState EndGameState)
 		{
 			return;
 		}
-		
-		CurrentSaveToDiskDataRowRef->CurrentLevelProgression += GetProgressionReward(EndGameState);
+
+		const int32 NewProgression = CurrentSaveToDiskDataRowRef->CurrentLevelProgression + GetProgressionReward(EndGameState);
+		CurrentSaveToDiskDataRowRef->CurrentLevelProgression = FMath::Min(NewProgression, CurrentProgressionSettingsRowData.PointsToUnlock);
 
 		// Check if the current level progression has reached or surpassed the points needed to unlock
 		if (CurrentSaveToDiskDataRowRef->CurrentLevelProgression >= CurrentProgressionSettingsRowData.PointsToUnlock)

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -379,8 +379,9 @@ void UPSWorldSubsystem::SaveDataAsync()
 	const FPSSaveToDiskData& CurrenSaveToDiskDataRow = GetCurrentSaveToDiskRowByName();
 	const FPSRowData& CurrenProgressionSettingsRow = GetCurrentProgressionSettingsRowByName();
 
-	OnCurrentScoreChanged.Broadcast(CurrenSaveToDiskDataRow, CurrenProgressionSettingsRow);
 	UpdateProgressionStarActors();
+	OnCurrentScoreChanged.Broadcast(CurrenSaveToDiskDataRow, CurrenProgressionSettingsRow);
+s
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -168,6 +168,7 @@ void UPSWorldSubsystem::OnLocalCharacterReady_Implementation(APlayerCharacter* P
 // Subscribes to the end game state change notification on the player state. 
 void UPSWorldSubsystem::OnLocalPlayerStateReady_Implementation(AMyPlayerState* PlayerState, int32 CharacterID)
 {
+	checkf(PlayerState, TEXT("ERROR: [%i] %hs:\n'PlayerState' is null!"), __LINE__, __FUNCTION__);
 	PlayerState->OnEndGameStateChanged.AddUniqueDynamic(this, &ThisClass::OnEndGameStateChanged);
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -168,11 +168,6 @@ void UPSWorldSubsystem::OnLocalCharacterReady_Implementation(APlayerCharacter* P
 // Subscribes to the end game state change notification on the player state. 
 void UPSWorldSubsystem::OnLocalPlayerStateReady_Implementation(AMyPlayerState* PlayerState, int32 CharacterID)
 {
-	// Ensure that PlayerState is not null before subscribing to the event
-	if (!ensureMsgf(PlayerState, TEXT("ASSERT: [%i] %hs:\n'PlayerState' is null!"), __LINE__, __FUNCTION__))
-	{
-		return;
-	}
 	PlayerState->OnEndGameStateChanged.AddUniqueDynamic(this, &ThisClass::OnEndGameStateChanged);
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -15,13 +15,11 @@
 #include "MyUtilsLibraries/UtilsLibrary.h"
 #include "Engine/Engine.h"
 #include "Engine/World.h"
-#include "GameFramework/MyGameStateBase.h"
 #include "LevelActors/PSStarActor.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "MyUtilsLibraries/GameplayUtilsLibrary.h"
 #include "Subsystems/GameDifficultySubsystem.h"
 #include "Subsystems/GlobalEventsSubsystem.h"
-#include "Materials/MaterialInstanceDynamic.h"
 #include "UtilityLibraries/MyBlueprintFunctionLibrary.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(PSWorldSubsystem)
@@ -131,6 +129,10 @@ void UPSWorldSubsystem::OnInitialized_Implementation()
 
 	// Subscribe events on player type changed and Character spawned
 	BIND_ON_LOCAL_CHARACTER_READY(this, ThisClass::OnLocalCharacterReady);
+
+	// Binds the local player state ready event to the handler
+	BIND_ON_LOCAL_PLAYER_STATE_READY(this, ThisClass::OnLocalPlayerStateReady);
+	
 }
 
 // Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors 
@@ -164,10 +166,40 @@ void UPSWorldSubsystem::OnLocalCharacterReady_Implementation(APlayerCharacter* P
 	PlayerCharacter->OnPlayerTypeChanged.AddUniqueDynamic(this, &ThisClass::OnPlayerTypeChanged);
 }
 
+// Subscribes to the end game state change notification on the player state. 
+void UPSWorldSubsystem::OnLocalPlayerStateReady_Implementation(AMyPlayerState* PlayerState, int32 CharacterID)
+{
+	// Ensure that PlayerState is not null before subscribing to the event
+	if (!ensureMsgf(PlayerState, TEXT("ASSERT: [%i] %hs:\n'PlayerState' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+	PlayerState->OnEndGameStateChanged.AddUniqueDynamic(this, &ThisClass::OnEndGameStateChanged);
+}
+
 // Is called when a player has been changed
 void UPSWorldSubsystem::OnPlayerTypeChanged_Implementation(FPlayerTag PlayerTag)
 {
 	SetCurrentRowByTag(PlayerTag);
+}
+
+// Called when the end game state was changed to recalculate progression according to endgame (win, loss etc.) 
+void UPSWorldSubsystem::OnEndGameStateChanged_Implementation(EEndGameState EndGameState)
+{
+	if (EndGameState != EEndGameState::None)
+	{
+		SavePoints(EndGameState);
+	}
+}
+
+// Save the progression depends on EEndGameState. 
+void UPSWorldSubsystem::SavePoints(EEndGameState EndGameState)
+{
+	if (!ensureMsgf(SaveGameDataInternal, TEXT("ASSERT: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__))
+	{
+		return;
+	}
+	SaveGameDataInternal->SavePoints(EndGameState);
 }
 
 // Always set first levels as unlocked on begin play
@@ -354,6 +386,7 @@ void UPSWorldSubsystem::SaveDataAsync()
 	const FPSRowData& CurrenProgressionSettingsRow = GetCurrentProgressionSettingsRowByName();
 
 	OnCurrentScoreChanged.Broadcast(CurrenSaveToDiskDataRow, CurrenProgressionSettingsRow);
+	UpdateProgressionStarActors();
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
 

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -381,7 +381,7 @@ void UPSWorldSubsystem::SaveDataAsync()
 
 	UpdateProgressionStarActors();
 	OnCurrentScoreChanged.Broadcast(CurrenSaveToDiskDataRow, CurrenProgressionSettingsRow);
-s
+
 	UGameplayStatics::AsyncSaveGameToSlot(SaveGameDataInternal, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), SaveGameDataInternal->GetSaveSlotIndex());
 }
 

--- a/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
+++ b/Source/ProgressionSystemRuntime/Public/Components/PSHUDComponent.h
@@ -21,10 +21,6 @@ class PROGRESSIONSYSTEMRUNTIME_API UPSHUDComponent final : public UActorComponen
 public:
 	/** Sets default values for this component's properties. */
 	UPSHUDComponent();
-
-	/** Save the progression depends on EEndGameState. */
-	UFUNCTION(BlueprintCallable, Category="C++")
-	void SavePoints(EEndGameState EndGameState);
 	
 	/*********************************************************************************************
 	* Protected properties
@@ -46,20 +42,12 @@ protected:
 	 * Once the save file is loaded it activates the functionality of this class */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnInitialized();
-	
-	/** Subscribes to the end game state change notification on the player state. */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnLocalPlayerStateReady(AMyPlayerState* PlayerState, int32 CharacterID);
 
 	/** Called when the game starts. */
 	virtual void BeginPlay() override;
 
 	/** Clears all transient data created by this component. */
 	virtual void OnUnregister() override;
-
-	/** Called when the end game state was changed. */
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnEndGameStateChanged(EEndGameState EndGameState);
 
 	/** Is called when local player character is ready to guarantee that they player controller is initialized for the Widget SubSystem */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -192,7 +192,7 @@ protected:
 	void OnEndGameStateChanged(EEndGameState EndGameState);
 
 	/** Save the progression depends on EEndGameState. */
-	UFUNCTION(BlueprintCallable, Category="C++")
+	UFUNCTION(BlueprintCallable, Category="C++", meta = (BlueprintProtected))
 	void SavePoints(EEndGameState EndGameState);
 	
 	/** Set first element as current active */

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -179,10 +179,22 @@ protected:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnLocalCharacterReady(class APlayerCharacter* PlayerCharacter, int32 CharacterID);
 
+	/** Subscribes to the end game state change notification on the player state. */
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnLocalPlayerStateReady(AMyPlayerState* PlayerState, int32 CharacterID);
+
 	/** Is called when a player has been changed */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
+	/** // Called when the end game state was changed to recalculate progression according to endgame (win, loss etc.)  */
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
+	void OnEndGameStateChanged(EEndGameState EndGameState);
+
+	/** Save the progression depends on EEndGameState. */
+	UFUNCTION(BlueprintCallable, Category="C++")
+	void SavePoints(EEndGameState EndGameState);
+	
 	/** Set first element as current active */
 	UFUNCTION(BlueprintCallable, Category= "C++", meta = (BlueprintProtected))
 	void SetFirstElementAsCurrent();

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -187,7 +187,7 @@ protected:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnPlayerTypeChanged(FPlayerTag PlayerTag);
 
-	/** // Called when the end game state was changed to recalculate progression according to endgame (win, loss etc.)  */
+	/** Called when the end game state was changed to recalculate progression according to endgame (win, loss etc.)  */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnEndGameStateChanged(EEndGameState EndGameState);
 


### PR DESCRIPTION
https://trello.com/c/2h241Yqb/909-ps-refactor-stop-adding-score-into-total-score-if-max-starts-achieved
https://trello.com/c/kfPwiZEs/856-38ps-display-credits-on-progression-finished

1. Moved logic of saving points from HUDComponent to Subsystem.
2.  Restricted to add more stars than can be achieved by level.
3.  Added logic to trigger delegate when progression is completed
4. Fixed bug with stars not getting updated on return back to menu 

**To subscribe to the event:** 
![image](https://github.com/user-attachments/assets/480ff875-e8ec-4add-a93a-001191212528)

**Example of execution:** 
![image](https://github.com/user-attachments/assets/9b8672c1-a775-45d0-80c3-02a740ce49b6)

