### PR TITLE
[Bug][UE5.5] Fixed stars dont appear on client-only

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -17,7 +17,7 @@
 #include "Engine/World.h"
 #include "LevelActors/PSStarActor.h"
 #include "Materials/MaterialInstanceDynamic.h"
-#include "MyUtilsLibraries/GameplayUtilsLibrary.h"
+#include "MyUtilsLibraries/SaveUtilsLibrary.h"
 #include "Subsystems/GameDifficultySubsystem.h"
 #include "Subsystems/GlobalEventsSubsystem.h"
 #include "UtilityLibraries/MyBlueprintFunctionLibrary.h"
@@ -155,9 +155,9 @@ void UPSWorldSubsystem::Deinitialize()
 void UPSWorldSubsystem::OnWorldSubSystemInitialize_Implementation()
 {
 	// Load save game data of the Progression system
-	FAsyncLoadGameFromSlotDelegate AsyncLoadGameFromSlotDelegate;
+	FAsyncLoadGameFromSlot AsyncLoadGameFromSlotDelegate;
 	AsyncLoadGameFromSlotDelegate.BindUObject(this, &ThisClass::OnAsyncLoadGameFromSlotCompleted);
-	UGameplayStatics::AsyncLoadGameFromSlot(UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), UPSSaveGameData::GetSaveSlotIndex(), AsyncLoadGameFromSlotDelegate);
+	USaveUtilsLibrary::AsyncLoadGameFromSlot(this, UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal), UPSSaveGameData::GetSaveSlotIndex(), AsyncLoadGameFromSlotDelegate);
 }
 
 // Is called when a player character is ready
@@ -333,7 +333,7 @@ UMaterialInstanceDynamic* UPSWorldSubsystem::GetStarProgressionDynamicMaterial(E
 }
 
 // Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load.
-void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(const FString& SlotName, int32 UserIndex, USaveGame* SaveGame)
+void UPSWorldSubsystem::OnAsyncLoadGameFromSlotCompleted_Implementation(USaveGame* SaveGame)
 {
 	// load from data table
 	const UDataTable* ProgressionDataTable = UPSDataAsset::Get().GetProgressionDataTable();
@@ -413,7 +413,7 @@ void UPSWorldSubsystem::ResetSaveGameData()
 	const FString& SlotName = UPSSaveGameData::GetSaveSlotName(SaveFileVersionExtensionInternal);
 	const int32 UserIndex = UPSSaveGameData::GetSaveSlotIndex();
 
-	SaveGameDataInternal = Cast<UPSSaveGameData>(UGameplayUtilsLibrary::ResetSaveGameData(SaveGameDataInternal, SlotName, UserIndex));
+	SaveGameDataInternal = USaveUtilsLibrary::ResetSaveGameData<UPSSaveGameData>(SaveGameDataInternal, SlotName, UserIndex);
 	checkf(SaveGameDataInternal, TEXT("ERROR: [%i] %hs:\n'SaveGameDataInternal' is null!"), __LINE__, __FUNCTION__);
 
 	// load from data table

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -226,5 +226,5 @@ protected:
 
 	/** Is called from AsyncLoadGameFromSlot once Save Game is loaded, or null if it failed to load. */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
-	void OnAsyncLoadGameFromSlotCompleted(const FString& SlotName, int32 UserIndex, class USaveGame* SaveGame);
+	void OnAsyncLoadGameFromSlotCompleted(class USaveGame* SaveGame);
 };


### PR DESCRIPTION
Calling own `USaveUtilsLibrary::AsyncLoadGameFromSlot` method instead of engine's `UGameplayStatics::AsyncLoadGameFromSlot`, which ensures callback will be called in the correct world context, even in PIE multiplayer.

It fixes next issues:
https://trello.com/c/Dbcqhz2g
https://trello.com/c/qbEWAfvF

Results, editor client-only, all stars are present:
![image](https://github.com/user-attachments/assets/6c3fbea5-1d01-4038-8e4c-3239cbf293a3)

Debug also confirms knowledge of client context (before it was always server):  
![image](https://github.com/user-attachments/assets/52ab7451-33fe-447d-9e0e-8e7084ad199d)
