### PR TITLE
Stars missing on menu after returning from very first game session with zero progression (fresh install or deleted saves)

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/LevelActors/PSStarActor.cpp
+++ b/Source/ProgressionSystemRuntime/Private/LevelActors/PSStarActor.cpp
@@ -73,6 +73,7 @@ void APSStarActor::OnGameStateChanged_Implementation(ECurrentGameState GameState
 {
 	if (GameState == ECurrentGameState::Menu)
 	{
+		SetActorHiddenInGame(false); 
 		SetStartTimeMenuStars();
 		TryPlayMenuStarAnimation();
 	}


### PR DESCRIPTION
https://trello.com/c/C261Cudr/925-mediumbugpsbuild-stars-missing-on-menu-after-returning-from-very-first-game-session-with-zero-progression-fresh-install-or-delet
https://github.com/user-attachments/assets/520a51d3-b4a5-47a2-a218-a2c7511f8053

For some reason Actor Hidden In Game parameters vs automatically applied and never reverted back. I believe this is related to the PoolManager  Since it has logic to make Actors inactive once returned to the pool, this is only an assumption. 
![image](https://github.com/user-attachments/assets/e903ab91-5974-4ce1-b3f7-a23baa887082)



