### PR TITLE
Added global message cleanup and MGF subsystem lifecycle: listeners auto-unbind on lifetime end, cached messages clear on plugin unload, and all MGF world subsystems now inherit retriggerable base class tied to owning game feature lifecycle 

### DIFF
--- a/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
@@ -71,6 +71,8 @@ void UPSHUDComponent::OnUnregister()
 {
 	Super::OnUnregister();
 
+	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
+
 	UPSWorldSubsystem::Get().PerformCleanUp();
 
 	if (UBmrWidgetsSubsystem* WidgetsSubsystem = UBmrWidgetsSubsystem::GetWidgetsSubsystem())

--- a/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSHUDComponent.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Valerii Rotermel & Yevhenii Selivanov
+// Copyright (c) Valerii Rotermel & Yevhenii Selivanov
 
 #include "Components/PSHUDComponent.h"
 
@@ -72,8 +72,6 @@ void UPSHUDComponent::OnUnregister()
 	Super::OnUnregister();
 
 	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
-
-	UPSWorldSubsystem::Get().PerformCleanUp();
 
 	if (UBmrWidgetsSubsystem* WidgetsSubsystem = UBmrWidgetsSubsystem::GetWidgetsSubsystem())
 	{

--- a/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Components/PSSpotComponent.cpp
@@ -97,6 +97,8 @@ void UPSSpotComponent::BeginPlay()
 // Clears all transient data created by this component.
 void UPSSpotComponent::OnUnregister()
 {
+	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
+
 	// reset back to initial state. By default, the spot is unlocked
 	constexpr bool bSpotUnlocked = true;
 	GetMeshChecked().SetActive(bSpotUnlocked);

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -159,18 +159,12 @@ void UPSWorldSubsystem::OnInitialized_Implementation()
 	UGlobalMessageSubsystem::CallOrStartListeningForGlobalMessage(BmrGameplayTags::Event::Player_LocalPawnReady, this, &ThisClass::OnLocalPawnReady);
 }
 
-// Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors
-void UPSWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
-{
-	Super::OnWorldBeginPlay(InWorld);
-}
-
 // Clears all transient data created by this subsystem
-void UPSWorldSubsystem::OnWorldEndPlay(UWorld& InWorld)
+void UPSWorldSubsystem::OnGameFeatureDeinitialize_Implementation()
 {
 	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
 
-	Super::OnWorldEndPlay(InWorld);
+	PerformCleanUp();
 }
 
 // Is called to initialize the world subsystem. It's a BeginPlay logic for the PS module

--- a/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Data/PSWorldSubsystem.cpp
@@ -166,9 +166,11 @@ void UPSWorldSubsystem::OnWorldBeginPlay(UWorld& InWorld)
 }
 
 // Clears all transient data created by this subsystem
-void UPSWorldSubsystem::Deinitialize()
+void UPSWorldSubsystem::OnWorldEndPlay(UWorld& InWorld)
 {
-	Super::Deinitialize();
+	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
+
+	Super::OnWorldEndPlay(InWorld);
 }
 
 // Is called to initialize the world subsystem. It's a BeginPlay logic for the PS module

--- a/Source/ProgressionSystemRuntime/Private/LevelActors/PSStarActor.cpp
+++ b/Source/ProgressionSystemRuntime/Private/LevelActors/PSStarActor.cpp
@@ -50,6 +50,14 @@ void APSStarActor::BeginPlay()
 	UGlobalMessageSubsystem::CallOrStartListeningForGlobalMessage(BmrGameplayTags::Event::GameState_Changed, this, &ThisClass::OnGameStateChanged);
 }
 
+// Called when this actor is explicitly being destroyed during gameplay or in the editor, not called during level streaming or gameplay ending
+void APSStarActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
+
+	Super::EndPlay(EndPlayReason);
+}
+
 // Function called every frame on this Actor
 void APSStarActor::Tick(float DeltaTime)
 {

--- a/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
+++ b/Source/ProgressionSystemRuntime/Private/Widgets/PSEndGameWidget.cpp
@@ -54,6 +54,8 @@ void UPSEndGameWidget::NativeDestruct()
 		UPoolManagerSubsystem::Get().EmptyPool(UPSDataAsset::Get().GetStarWidgetClass());
 	}
 
+	UGlobalMessageSubsystem::StopListeningForAllGlobalMessages(this);
+
 	Super::NativeDestruct();
 }
 

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -4,7 +4,7 @@
 
 #include "Data/PoolObjectHandle.h"
 #include "PSTypes.h"
-#include "Subsystems/WorldSubsystem.h"
+#include "Subsystems/ModularGameFeaturePluginSubsystem.h"
 
 #include "PSWorldSubsystem.generated.h"
 
@@ -14,7 +14,7 @@ enum class EPSStarActorState : uint8;
  * Implements the world subsystem to access different components in the module
  */
 UCLASS(BlueprintType, Blueprintable, Config = "ProgressionSystem", DefaultConfig)
-class PROGRESSIONSYSTEMRUNTIME_API UPSWorldSubsystem : public UWorldSubsystem
+class PROGRESSIONSYSTEMRUNTIME_API UPSWorldSubsystem : public UModularGameFeaturePluginSubsystem
 {
 	GENERATED_BODY()
 
@@ -181,11 +181,8 @@ protected:
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))
 	void OnInitialized();
 
-	/** Called when world is ready to start gameplay before the game mode transitions to the correct state and call BeginPlay on all actors */
-	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
-
-	/** Clears all transient data created by this subsystem. */
-	virtual void OnWorldEndPlay(UWorld& InWorld) override;
+	/** Clears all transient data created by this subsystem */
+	virtual void OnGameFeatureDeinitialize_Implementation() override;
 
 	/** Is called when a player character is ready */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))

--- a/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
+++ b/Source/ProgressionSystemRuntime/Public/Data/PSWorldSubsystem.h
@@ -185,7 +185,7 @@ protected:
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
 
 	/** Clears all transient data created by this subsystem. */
-	virtual void Deinitialize() override;
+	virtual void OnWorldEndPlay(UWorld& InWorld) override;
 
 	/** Is called when a player character is ready */
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "C++", meta = (BlueprintProtected))

--- a/Source/ProgressionSystemRuntime/Public/LevelActors/PSStarActor.h
+++ b/Source/ProgressionSystemRuntime/Public/LevelActors/PSStarActor.h
@@ -50,6 +50,9 @@ protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
 
+	/** Called when this actor is explicitly being destroyed during gameplay or in the editor, not called during level streaming or gameplay ending */
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
 	/** Function called every frame on this Actor */
 	virtual void Tick(float DeltaTime) override;
 


### PR DESCRIPTION
- Added global message listener cleanup and MGF cache clearing: all listeners unbind on lifetime end, MGF-owned events clear stale cached data on unload so early-binding listeners receive fresh payloads on next activation
- Converted all MGF world subsystems to new base class with proper lifecycle tied to own game feature plugin